### PR TITLE
supervisord.conf using the correct ports to run the swf-testbed 

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -69,7 +69,7 @@ stderr_logfile=%(here)s/logs/%(program_name)s_stderr.log
 stopsignal=QUIT
 
 [program:swf-monitor-web]
-command=python src/manage.py runserver 0.0.0.0:8000
+command=python src/manage.py runserver 0.0.0.0:8002
 directory=%(ENV_SWF_HOME)s/swf-monitor
 autostart=true
 autorestart=true
@@ -78,7 +78,7 @@ stderr_logfile=%(here)s/logs/%(program_name)s_stderr.log
 stopsignal=QUIT
 
 [program:swf-monitor-daphne]
-command=daphne -p 8001 swf_monitor_project.asgi:application
+command=daphne -e ssl:8443:privateKey=../ssl_key.pem:certKey=../ssl_cert.pem:interface=0.0.0.0 swf_monitor_project.asgi:application
 directory=%(ENV_SWF_HOME)s/swf-monitor/src
 autostart=true
 autorestart=true


### PR DESCRIPTION
Ports and daphne ssl configuration must be updated to run the monitor instance in a local dev enviroment. 