### PR TITLE
v21: SSE Command-Line Filtering and Usability Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This document contains mandatory critical thinking requirements, coding rules, a
 ### Operations
 - [**Running the Testbed**](docs/operations.md) - Starting, stopping, and monitoring services
 - [**Monitor Integration**](docs/monitor.md) - Web interface and API usage
+- [**SSE Real-Time Streaming**](docs/sse-streaming.md) - Remote workflow event monitoring via HTTPS
 - [**Production Deployment**](../swf-monitor/docs/PRODUCTION_DEPLOYMENT.md) - Complete Apache production deployment guide
 
 ### Development

--- a/docs/sse-streaming.md
+++ b/docs/sse-streaming.md
@@ -1,0 +1,265 @@
+# Server-Sent Events (SSE) Real-Time Streaming
+
+Real-time workflow message streaming for remote monitoring and visualization via HTTPS Server-Sent Events.
+
+## Overview
+
+The SWF Testbed provides real-time streaming of workflow messages to remote clients via REST Server-Sent Events (SSE). This enables distributed agents and external systems to receive live workflow updates without requiring direct ActiveMQ access or complex networking configurations.
+
+**Key Benefits:**
+- **Firewall-friendly**: Uses standard HTTPS connections 
+- **Real-time**: Sub-second latency for workflow messages
+- **Scalable**: Supports multiple concurrent remote clients
+- **Secure**: Token-based authentication with production TLS
+- **Filtered**: Clients can subscribe to specific message types or workflows
+
+## Architecture
+
+```
+Workflow Agents → ActiveMQ → Monitor → SSE Broadcaster → Remote Agents
+     ↓              ↓           ↓           ↓              
+  data-agent    epictopic   Database   Server-side    
+processing-agent            Logging    Filtering      
+  daq-simulator                                       
+```
+
+**Data Flow:**
+1. **Workflow agents** send messages to ActiveMQ (normal operation)
+2. **Monitor** consumes messages, stores in database, enriches with metadata  
+3. **SSE Broadcaster** applies per-client filters and forwards only matching messages
+4. **Remote clients** receive filtered real-time message streams over the network
+
+## SSE Clients (Receivers)
+
+### Remote SSE Receiver
+
+The `remote_sse_receiver.py` script connects to the production monitor and displays workflow messages in real-time.
+
+#### Prerequisites
+
+```bash
+export SWF_API_TOKEN="your-production-api-token"
+export SWF_SSE_RECEIVER_NAME="descriptive-client-name"
+```
+
+**Important:** `SWF_SSE_RECEIVER_NAME` must be set to a descriptive, unique name that identifies your remote agent. This name will appear in the monitor's agent registry and workflow views.
+
+#### Usage
+
+```bash
+# Basic usage (receives ALL messages)
+cd /eic/u/wenauseic/github/swf-testbed
+source .venv/bin/activate && source ~/.env
+export SWF_SSE_RECEIVER_NAME="my-fastmon"
+python example_agents/remote_sse_receiver.py
+
+```
+
+#### Filtering Examples
+
+To add filtering to `remote_sse_receiver.py`, modify the stream URL:
+
+**Only STF generation messages:**
+```python
+# In remote_sse_receiver.py connect_and_receive():
+stream_url = f"{self.monitor_base}/api/messages/stream/?msg_types=stf_gen"
+```
+
+**Only processing completion from specific agent:**
+```python
+# In remote_sse_receiver.py connect_and_receive():
+stream_url = f"{self.monitor_base}/api/messages/stream/?msg_types=processing_complete&agents=processing-agent"
+```
+
+**All messages from specific run:**
+```python
+# In remote_sse_receiver.py connect_and_receive():
+stream_url = f"{self.monitor_base}/api/messages/stream/?run_ids=run-2025-001"
+```
+
+**Note**: The current `remote_sse_receiver.py` does not implement filtering query parameters. To add filtering, modify the `stream_url` as shown in the examples above.
+
+#### Features
+
+- **Authentication**: Automatic token-based authentication
+- **Auto-reconnection**: Handles network interruptions gracefully
+- **No filtering**: Receives ALL ActiveMQ messages (unfiltered stream)
+- **Agent registration**: Registers as active monitoring client
+- **Real-time display**: Formatted message output with timestamps
+
+#### Output Example
+
+```
+📡 Connecting to SSE stream: https://pandaserver02.sdcc.bnl.gov/swf-monitor/api/messages/stream/
+🔌 Testing SSE endpoint...
+✅ SSE stream opened - waiting for messages... (Ctrl+C to exit)
+------------------------------------------------------------
+[14:30:25] 🔗 Connected to SSE stream
+[14:30:25] 📋 Client ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+[14:30:28] 📨 Message received:
+            Type: stf_gen
+            From: daq-simulator-agent
+            Run:  run-2025-001
+            File: stf_001.dat
+------------------------------------------------------------
+```
+
+### Integration Requirements
+
+SSE clients must:
+1. **Set descriptive name**: `SWF_SSE_RECEIVER_NAME` environment variable
+2. **Authenticate**: Valid `SWF_API_TOKEN` for production access
+3. **Register as agent**: Inherit from `BaseAgent` to appear in monitor views and for robust connection handling
+
+## Server-Side Filtering and Network Efficiency
+
+### **How Filtering Works**
+
+**ALL ActiveMQ messages** are processed by the SSE system, but **server-side filtering prevents unwanted messages from being sent over the network**.
+
+#### Code Evidence:
+1. **Every ActiveMQ message** triggers SSE processing:
+   ```python
+   # activemq_processor.py:158
+   broadcaster.broadcast_message(enriched)
+   ```
+
+2. **Server applies filters BEFORE sending to clients**:
+   ```python
+   # sse_views.py:127
+   if self._message_matches_filters(message_data, self.client_filters.get(client_id, {})):
+       client_queue.put_nowait(message_data)  # Only filtered messages queued
+   ```
+
+3. **Filter implementation rejects unwanted messages**:
+   ```python
+   # sse_views.py:160-161
+   if 'msg_types' in filters:
+       if message.get('msg_type') not in filters['msg_types']:
+           return False  # Message filtered out, NOT sent to client
+   ```
+
+### **Network Traffic Control**
+
+- ✅ **No unnecessary network traffic**: Filtered messages never leave the server
+- ✅ **Server-side filtering**: Applied before network transmission  
+- ✅ **Per-client filtering**: Each client receives only matching messages
+
+### **Filter Types and Examples**
+
+#### Available Filters:
+- `msg_types` - Filter by message type
+- `agents` - Filter by sender agent (`processed_by` field)
+- `run_ids` - Filter by workflow run ID
+
+## Message Types and Content
+
+SSE clients receive workflow messages (subject to their filters) with enriched metadata:
+
+### Standard Workflow Messages
+- `run_imminent` - New run about to start
+- `start_run` - Run initialization complete
+- `stf_gen` - New STF data file available  
+- `data_ready` - Data processing ready
+- `processing_complete` - Processing finished
+- `pause_run` / `resume_run` - Run control
+- `end_run` - Run completed
+
+### Message Structure
+```json
+{
+  "msg_type": "stf_gen",
+  "processed_by": "daq-simulator-agent", 
+  "run_id": "run-2025-001",
+  "filename": "stf_001.dat",
+  "message": "STF file generated",
+  "sender_agent": "daq-simulator-agent",
+  "recipient_agent": "data-agent",
+  "queue_name": "epictopic",
+  "sent_at": "2025-01-15T14:30:25.123Z"
+}
+```
+
+### Test Messages
+- `sse_test` - Connectivity and functionality testing
+
+## Security and Authentication
+
+### Production Authentication
+SSE streaming requires valid API tokens:
+
+```bash
+# Get token from monitor admin
+export SWF_API_TOKEN="your-token-here"
+```
+
+### Network Security
+- **HTTPS only**: All SSE connections use TLS encryption
+- **Token authentication**: No credentials in URLs or query parameters  
+- **Firewall friendly**: Outbound HTTPS (port 443) only
+- **No incoming connections**: Clients connect to monitor, not vice versa
+
+## Deployment Considerations
+
+### Monitor Requirements
+- **Redis**: Required for multi-process SSE fanout in production
+- **Apache configuration**: Proper headers for SSE streaming
+- **Database storage**: All messages persisted for audit/replay
+
+### Client Requirements  
+- **Persistent connection**: SSE requires long-lived HTTPS connections
+- **Reconnection logic**: Handle temporary network disruptions
+- **Resource management**: Proper cleanup on shutdown
+- **Agent registration**: Must appear in monitor's agent registry
+
+### Scaling
+- **Multiple clients**: Monitor supports concurrent SSE connections
+- **Message filtering**: Clients can filter by message type, agent, or run
+- **Latency**: Sub-second delivery for real-time monitoring
+
+## Development and Testing
+
+### Test Message Generation
+Use `remote_sse_sender.py` to generate test messages:
+
+```bash
+# One-shot test batch
+export SWF_SENDER_ONESHOT=1  
+python example_agents/remote_sse_sender.py
+
+# Continuous test messages (every 30s)
+python example_agents/remote_sse_sender.py
+```
+
+
+## Troubleshooting
+
+### Common Issues
+
+**Connection Refused (ECONNREFUSED)**
+- Check monitor URL and network connectivity
+- Verify production monitor is running
+
+**HTTP 401 Unauthorized**  
+- Verify `SWF_API_TOKEN` is set and valid
+- Check token hasn't expired
+
+
+**Missing Agent Name Error**
+```
+❌ Error: SWF_SSE_RECEIVER_NAME must be set to a descriptive agent name
+```
+Set descriptive client identifier:
+```bash
+export SWF_SSE_RECEIVER_NAME="workflow-dashboard"
+```
+
+### Monitoring SSE Health
+Check connected clients in monitor web interface:
+- **System Agents**: View registered SSE receivers
+- **Workflow Messages**: See message delivery status  
+- **API Status**: `/api/messages/stream/status/` endpoint
+
+---
+
+For technical implementation details, see [Monitor SSE Documentation](../swf-monitor/docs/SSE_RELAY.md).

--- a/docs/sse-streaming.md
+++ b/docs/sse-streaming.md
@@ -6,6 +6,8 @@ Real-time workflow message streaming for remote monitoring and visualization via
 
 The SWF Testbed provides real-time streaming of workflow messages to remote clients via REST Server-Sent Events (SSE). This enables distributed agents and external systems to receive live workflow updates without requiring direct ActiveMQ access or complex networking configurations.
 
+**Important**: ActiveMQ message senders require no modifications. ALL messages sent to ActiveMQ are automatically available to SSE clients. Only receiving agents need SSE-specific configuration.
+
 **Key Benefits:**
 - **Firewall-friendly**: Uses standard HTTPS connections 
 - **Real-time**: Sub-second latency for workflow messages

--- a/example_agents/remote_sse_receiver.py
+++ b/example_agents/remote_sse_receiver.py
@@ -5,6 +5,12 @@ Remote SSE Receiver: Connects to the monitor's SSE stream to receive workflow me
 This script receives real-time workflow messages via Server-Sent Events (SSE)
 from the swf-monitor running under production Apache. It connects to the SSE
 endpoint and logs received messages.
+
+Command-line filtering examples (based on remote_sse_sender.py messages):
+  python remote_sse_receiver.py --message sse_test
+  python remote_sse_receiver.py --message data_ready,processing_complete  
+  python remote_sse_receiver.py --agent sse_sender-agent
+  python remote_sse_receiver.py --message sse_test --agent sse_sender-agent
 """
 
 import os
@@ -12,9 +18,11 @@ import sys
 import time
 import json
 import signal
+import argparse
 from pathlib import Path
 
 import requests
+from swf_common_lib.base_agent import BaseAgent
 
 # Canonical production base URL (can be overridden by SWF_MONITOR_PROD_URL)
 DEFAULT_MONITOR_BASE = "https://pandaserver02.sdcc.bnl.gov/swf-monitor"
@@ -34,26 +42,34 @@ def setup_environment() -> None:
                 os.environ[key.strip()] = value.strip("'\"")
 
 
-class RemoteSSEReceiver:
-    """Production-only SSE client for swf-monitor."""
+class RemoteSSEReceiver(BaseAgent):
+    """Production-only SSE client for swf-monitor that registers as an agent."""
 
-    def __init__(self) -> None:
+    def __init__(self, msg_types=None, agents=None) -> None:
         setup_environment()
 
         # Production monitor base URL (env override, otherwise production default)
         env_url = os.getenv('SWF_MONITOR_PROD_URL')
         if env_url:
-            self.monitor_base = env_url.rstrip('/')
+            monitor_base = env_url.rstrip('/')
         else:
-            self.monitor_base = DEFAULT_MONITOR_BASE
-            print(f"ℹ️  Using default production URL: {self.monitor_base} (override with SWF_MONITOR_PROD_URL)")
+            monitor_base = DEFAULT_MONITOR_BASE
+            print(f"ℹ️  Using default production URL: {monitor_base} (override with SWF_MONITOR_PROD_URL)")
 
-        self.api_token = os.getenv('SWF_API_TOKEN')
-        if not self.api_token:
-            print("❌ Error: SWF_API_TOKEN not set in environment")
-            sys.exit(1)
+        # Override monitor URLs for production
+        os.environ['SWF_MONITOR_URL'] = monitor_base
+        os.environ['SWF_MONITOR_HTTP_URL'] = monitor_base
 
-        self.running = True
+        # Initialize BaseAgent with descriptive type and name
+        super().__init__(agent_type='sse_receiver', subscription_queue='epictopic')
+        
+        # Override agent name if user provided one
+        user_agent_name = os.getenv('SWF_SSE_RECEIVER_NAME')
+        if user_agent_name:
+            self.agent_name = user_agent_name
+        self.monitor_base = monitor_base
+        self.msg_types = msg_types
+        self.agents = agents
 
         # HTTP session: production defaults (verify=True, env proxies honored)
         self.session = requests.Session()
@@ -64,9 +80,9 @@ class RemoteSSEReceiver:
             'Connection': 'keep-alive',
         })
 
-        # Graceful shutdown
-        signal.signal(signal.SIGINT, self._signal_handler)
-        signal.signal(signal.SIGTERM, self._signal_handler)
+        # Simple shutdown - just exit immediately
+        signal.signal(signal.SIGINT, lambda signum, frame: sys.exit(0))
+        signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
         print("🔧 Remote SSE Receiver initialized")
         print(f"   Monitor base: {self.monitor_base}")
@@ -75,17 +91,22 @@ class RemoteSSEReceiver:
         if ca_bundle:
             print(f"   CA bundle:   {ca_bundle}")
 
-    def _signal_handler(self, signum, frame) -> None:
-        print(f"\n📡 Received signal {signum} - shutting down gracefully...")
-        self.running = False
 
     def connect_and_receive(self) -> None:
         """Connect to SSE stream and process messages in a loop."""
+        # Build stream URL with filters
         stream_url = f"{self.monitor_base}/api/messages/stream/"
+        params = []
+        if self.msg_types:
+            params.append(f"msg_types={','.join(self.msg_types)}")
+        if self.agents:
+            params.append(f"agents={','.join(self.agents)}")
+        if params:
+            stream_url += "?" + "&".join(params)
         status_url = f"{self.monitor_base}/api/messages/stream/status/"
         print(f"📡 Connecting to SSE stream: {stream_url}")
 
-        while self.running:
+        while True:
             try:
                 # Status precheck
                 print("🔌 Testing SSE endpoint...")
@@ -105,9 +126,8 @@ class RemoteSSEReceiver:
                         print("   Enable 'WSGIPassAuthorization On' in Apache for the /swf-monitor app and reload Apache.")
                     else:
                         print(f"❌ SSE endpoint not available: HTTP {status_resp.status_code}")
-                    if self.running:
-                        print("   Retrying in 15 seconds...")
-                        time.sleep(15)
+                    print("   Retrying in 15 seconds...")
+                    time.sleep(15)
                     continue
 
                 # Open the SSE stream (blocks quietly while waiting for events)
@@ -131,39 +151,36 @@ class RemoteSSEReceiver:
                             print(f"     {key}: {value}")
                         print("   Response Body:")
                         print(f"     {response.text}")
-                    if self.running:
-                        print("   Retrying in 15 seconds...")
-                        time.sleep(15)
+                    print("   Retrying in 15 seconds...")
+                    time.sleep(15)
                     continue
 
                 print("✅ SSE stream opened - waiting for events... (Ctrl+C to exit)")
+                
+                # Register this SSE receiver as an active agent
+                self.send_heartbeat()
+                
                 print("-" * 60)
                 # streaming until broken or stopped
                 self._process_sse_stream(response)
 
             except requests.exceptions.ReadTimeout as e:
                 print(f"⏱️  Read timeout while waiting for messages: {e}")
-                if self.running:
-                    print("   Reconnecting in 15 seconds...")
-                    time.sleep(15)
+                print("   Reconnecting in 15 seconds...")
+                time.sleep(15)
             except requests.exceptions.RequestException as e:
                 print(f"❌ Connection error: {e}")
-                if self.running:
-                    print("   Retrying in 15 seconds...")
-                    time.sleep(15)
+                print("   Retrying in 15 seconds...")
+                time.sleep(15)
             except Exception as e:
                 print(f"❌ Unexpected error: {e}")
-                if self.running:
-                    time.sleep(15)
+                time.sleep(15)
 
-        print("📡 SSE Receiver shutdown complete")
 
     def _process_sse_stream(self, response) -> None:
         event_buffer = []
         try:
             for line in response.iter_lines(decode_unicode=True, chunk_size=1):
-                if not self.running:
-                    break
                 if line is None:
                     continue
                 line = line.strip()
@@ -211,8 +228,8 @@ class RemoteSSEReceiver:
                 processed_by = data.get('processed_by', 'unknown')
                 run_id = data.get('run_id', 'N/A')
                 print(f"[{timestamp}] 📨 Message received:")
-                print(f"            Type: {msg_type}")
-                print(f"            From: {processed_by}")
+                print(f"         Message: {msg_type}")
+                print(f"           Agent: {processed_by}")
                 print(f"            Run:  {run_id}")
                 if 'message' in data:
                     print(f"            Text: {data['message']}")
@@ -226,8 +243,50 @@ class RemoteSSEReceiver:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remote SSE Receiver: Connect to workflow monitor SSE stream",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python remote_sse_receiver.py                           # Receive all messages
+  python remote_sse_receiver.py --message stf_gen         # Only STF generation messages
+  python remote_sse_receiver.py --agent daq-simulator     # Only messages from daq-simulator
+  python remote_sse_receiver.py --message stf_gen,data_ready --agent daq-simulator
+
+Environment variables:
+  SWF_SSE_RECEIVER_NAME - Required: descriptive agent name
+  SWF_API_TOKEN         - Required: monitor API token
+  SWF_MONITOR_PROD_URL  - Optional: override monitor URL
+        """)
+    
+    parser.add_argument('--message', '--msg-type', dest='msg_types',
+                        help='Filter by message type(s), comma-separated (e.g., stf_gen,data_ready)')
+    parser.add_argument('--agent', dest='agents', 
+                        help='Filter by agent name(s), comma-separated (e.g., daq-simulator,data-agent)')
+    
+    args = parser.parse_args()
+    
+    # Parse comma-separated values
+    msg_types = None
+    if args.msg_types:
+        msg_types = [t.strip() for t in args.msg_types.split(',')]
+    
+    agents = None
+    if args.agents:
+        agents = [a.strip() for a in args.agents.split(',')]
+    
     try:
-        receiver = RemoteSSEReceiver()
+        receiver = RemoteSSEReceiver(msg_types=msg_types, agents=agents)
+        if msg_types or agents:
+            filters = []
+            if msg_types:
+                filters.append(f"messages: {', '.join(msg_types)}")
+            if agents:
+                filters.append(f"agents: {', '.join(agents)}")
+            print(f"🔍 Filtering enabled - {' | '.join(filters)}")
+        else:
+            print("📬 Receiving all messages (no filtering)")
+        
         receiver.connect_and_receive()
     except KeyboardInterrupt:
         print("\n📡 Received interrupt signal - exiting...")

--- a/example_agents/remote_sse_sender.py
+++ b/example_agents/remote_sse_sender.py
@@ -26,26 +26,26 @@ class RemoteSSESender(BaseAgent):
         os.environ['SWF_MONITOR_URL'] = prod_base
         os.environ['SWF_MONITOR_HTTP_URL'] = prod_base
 
-        super().__init__(agent_type='SSE_SENDER', subscription_queue='epictopic')
+        super().__init__(agent_type='sse_sender', subscription_queue='epictopic')
         self.logger.info(f"Monitor base set to: {prod_base}")
         self.messages_to_send = [
             {
                 'msg_type': 'sse_test',
-                'processed_by': 'remote-sse-sender',
+                'processed_by': self.agent_name,
                 'run_id': 'test-run-001',
                 'message': 'Hello from SSE sender!',
                 'data': 'This is a test message for SSE demonstration'
             },
             {
                 'msg_type': 'data_ready',
-                'processed_by': 'remote-sse-sender', 
+                'processed_by': self.agent_name, 
                 'run_id': 'test-run-001',
                 'filename': 'test_file_001.dat',
                 'message': 'Simulated data ready event'
             },
             {
                 'msg_type': 'processing_complete',
-                'processed_by': 'remote-sse-sender',
+                'processed_by': self.agent_name,
                 'run_id': 'test-run-001', 
                 'filename': 'test_file_001.dat',
                 'message': 'Simulated processing complete event'
@@ -77,8 +77,13 @@ class RemoteSSESender(BaseAgent):
                             }
                         )
                         self.logger.info("Connected to ActiveMQ")
+                        self.mq_connected = True
+                        
+                        # Register agent with monitor via heartbeat
+                        self.send_heartbeat()
                     except Exception as e:
                         self.logger.error(f"Failed to connect to ActiveMQ: {e}")
+                        self.mq_connected = False
                         time.sleep(2)
                         continue
 


### PR DESCRIPTION
## Summary

SSE streaming improvements for remote workflow monitoring.

## Changes

- Command-line filtering: `--message` and `--agent` options for remote_sse_receiver.py
- Server-side filtering reduces network traffic
- Immediate exit on Ctrl+C instead of slow shutdown
- Fixed HTTP 406 error by removing DRF decorators from SSE endpoint
- Fixed agent registration and naming consistency
- Added SSE streaming documentation with examples

## Testing

✅ Command-line filtering works with production Apache deployment
✅ Compatible with existing ActiveMQ workflow agents  
✅ Agent registration appears correctly in monitor

🤖 Generated with [Claude Code](https://claude.ai/code)