### PR TITLE
infra/baseline-v33: Agent resilience, testbed monitoring, AI memory, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,12 @@ swf_list_logs(execution_id='...')         # Workflow logs
 
 ## Project-Specific Rules
 
-**Branch:** All 3 repos must be on `infra/baseline-v32` (shorthand: v30)
+**Branch:** All 3 repos must be on `infra/baseline-v33`
 
 **Deploy swf-monitor:** Commit and push first - deploy pulls from git, not local files.
 ```bash
 git add . && git commit -m "description" && git push
-sudo bash /data/wenauseic/github/swf-monitor/deploy-swf-monitor.sh branch infra/baseline-v32
+sudo bash /data/wenauseic/github/swf-monitor/deploy-swf-monitor.sh branch infra/baseline-v33
 ```
 
 **Git conventions:**

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ This is the umbrella repository for the ePIC streaming workflow testbed.
 - [**Workflow Orchestration**](docs/workflows.md) - Running and managing workflows
 - [**Monitor Integration**](docs/monitor.md) - Web interface and API usage
 - [**MCP Integration**](../swf-monitor/docs/MCP.md) - Model Context Protocol for LLM interaction
-- [**EMI (ePIC Metadata Interface)**](../swf-monitor/docs/EMI.md) - Production metadata tags for MC campaigns
+- [**PCS (Physics Configuration System)**](../swf-monitor/docs/PCS.md) - Production metadata tags for MC campaigns
 - [**SSE Real-Time Streaming**](docs/sse-streaming.md) - Remote workflow event monitoring via HTTPS
-- [**EMI (ePIC Metadata Interface)**](../swf-monitor/docs/EMI.md) - Production metadata tags for MC campaigns
 - [**Production Deployment**](../swf-monitor/docs/PRODUCTION_DEPLOYMENT.md) - Apache production deployment guide
 
 ### MCP for Claude Code

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ### PCS (Physics Configuration System) — New Django App (swf-monitor)
 
-A new Django app for managing production metadata tags for ePIC Monte Carlo simulation campaigns. PCS organizes metadata as tags — named parameter sets for each stage of the MC pipeline:
+A new Django app for configuring production tasks based on physics inputs for ePIC Monte Carlo simulation campaigns. PCS organizes configurations as tags — named parameter sets for each stage of the MC pipeline:
 
 - **Physics tags (p):** process, beam energies, species, Q2 range
 - **EvGen tags (e):** event generator and version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,9 @@
 
 ## v32 (2026-03-02)
 
-### EMI (ePIC Metadata Interface) — New Django App (swf-monitor)
+### PCS (Physics Configuration System) — New Django App (swf-monitor)
 
-A new Django app for managing production metadata tags for ePIC Monte Carlo simulation campaigns. EMI organizes metadata as tags — named parameter sets for each stage of the MC pipeline:
+A new Django app for managing production metadata tags for ePIC Monte Carlo simulation campaigns. PCS organizes metadata as tags — named parameter sets for each stage of the MC pipeline:
 
 - **Physics tags (p):** process, beam energies, species, Q2 range
 - **EvGen tags (e):** event generator and version
@@ -17,7 +17,7 @@ Tags have a draft/locked lifecycle. Locked tags are immutable and used in produc
 
 **Seeded data:** `seed_campaign_tags` management command creates 64 tags from the 26.02.0 campaign (47 physics, 15 evgen, 1 simu, 1 reco).
 
-**MCP tools:** `emi_list_tags`, `emi_get_tag`, `emi_search_tags`.
+**MCP tools:** `pcs_list_tags`, `pcs_get_tag`, `pcs_search_tags`.
 
 ### PanDA Mattermost Bot (swf-monitor)
 
@@ -25,7 +25,7 @@ Claude-based production monitoring chatbot in Mattermost. Listens in the `#panda
 
 - Discovers tools from MCP server automatically
 - System prompt built from MCP server instructions, stays in sync with deployed tool documentation
-- Supports PanDA and EMI tools
+- Supports PanDA and PCS tools
 - Thread-aware conversations
 
 ### PanDA Web Monitor (swf-monitor)


### PR DESCRIPTION
## infra/baseline-v33

Coordinated release across swf-monitor (188 commits), swf-testbed (18 commits), swf-common-lib (2 commits).

See swf-monitor PR for full release notes: https://github.com/BNLNPPS/swf-monitor/pull/28

### swf-testbed changes (18 commits)

- Agent manager: supervisord health verification, SIGUSR1 heartbeat, respect user config
- Exit heartbeat on shutdown so DB immediately reflects agent manager death
- check-testbed skill and supervisord health monitoring
- AI memory hooks for cross-session dialogue persistence (REST API)
- Fix workflow parameter override: auto-discover all config sections
- Docs cleanup, EMI→PCS rename, v31/v32/v33 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)