### PR TITLE
optimize fast processing workflow

### DIFF
--- a/docs/fast-processing-workflow.md
+++ b/docs/fast-processing-workflow.md
@@ -292,6 +292,125 @@ Run 101993 Summary:
     └── fast_processing-agent-wenauseic-483
 ```
 
+## Running the Fast Processing Agent
+
+### Prerequisites
+
+1. **Python Environment**: Activate the virtual environment
+   ```bash
+   source .venv/bin/activate
+   ```
+
+2. **Environment Variables**: Source the environment file containing:
+   - `ACTIVEMQ_HOST` - ActiveMQ broker address
+   - `ACTIVEMQ_PORT` - ActiveMQ broker port (default: 61612)
+   - `ACTIVEMQ_USER` - ActiveMQ username
+   - `ACTIVEMQ_PASSWORD` - ActiveMQ password
+   - `ACTIVEMQ_HEARTBEAT_TOPIC` - Heartbeat topic (e.g., 'epictopic')
+   - `ACTIVEMQ_USE_SSL` - Enable SSL connection (True/False)
+   - `ACTIVEMQ_SSL_CA_CERTS` - Path to SSL CA certificates
+   - `SWF_MONITOR_URL` and `SWF_MONITOR_HTTP_URL` - Monitor REST API endpoint
+   - Other testbed-specific variables
+
+   Example environment file (`~/.env`):
+   ```bash
+   export ACTIVEMQ_HOST='your-activemq-host'
+   export ACTIVEMQ_PORT='61612'
+   export ACTIVEMQ_USER='username'
+   export ACTIVEMQ_PASSWORD='password'
+   export ACTIVEMQ_HEARTBEAT_TOPIC='epictopic'
+   export ACTIVEMQ_USE_SSL=True
+   export ACTIVEMQ_SSL_CA_CERTS='/path/to/ca-certificates.crt'
+   export SWF_MONITOR_URL='http://your-monitor-api:8000'
+   export SWF_MONITOR_HTTP_URL='http://your-monitor-api:8000'
+   ```
+
+   Load the environment:
+   ```bash
+   source ~/.env
+   ```
+
+3. **Testbed Configuration**: Ensure `workflows/testbed.toml` exists with correct settings
+
+### Command Line Usage
+
+```bash
+python example_agents/fast_processing_agent.py \
+    --testbed-config workflows/testbed.toml \
+    --debug
+```
+
+#### Command Line Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--testbed-config` | Yes | Path to testbed configuration TOML file |
+| `--debug` | No | Enable debug logging for detailed output |
+
+### Example Run Script
+
+Create a shell script to run the agent:
+
+```bash
+#!/bin/bash
+# run_fast_processing.sh
+
+cd <some_path>/swf-project
+cd swf-testbed && source .venv/bin/activate && source ~/.env
+
+python example_agents/fast_processing_agent.py \
+    --testbed-config workflows/testbed.toml \
+    --debug
+```
+
+Make it executable:
+```bash
+chmod +x run_fast_processing.sh
+./run_fast_processing.sh
+```
+
+### What Happens at Startup
+
+1. **Initialization**:
+   - Connects to ActiveMQ broker
+   - Subscribes to `/topic/epictopic` (workflow messages)
+   - Subscribes to `/queue/panda.results.fastprocessing` (slice results)
+   - Fetches workflow execution parameters from Monitor API
+
+2. **Ready State**:
+   - Listens for `run_imminent` message
+   - Logs "Fast Processing Agent ready" to console
+
+3. **During Run**:
+   - Processes `tf_file_registered` messages
+   - Creates TF slices (15 per TF sample by default)
+   - Sends slices to `/topic/panda.slices`
+   - Broadcasts `run_imminent` and `end_run` to `/topic/panda.workers`
+   - Receives and processes slice results
+   - Updates TFSlice records in Monitor database
+
+### Monitoring Agent Activity
+
+Watch the console output for:
+```
+[INFO] Fast Processing Agent ready
+[INFO] Received run_imminent for run 101993
+[INFO] Broadcasting run_imminent to workers (target: 30)
+[INFO] Received tf_file_registered: swf.101993.000001_tf_001.tf
+[INFO] Created 15 slices for TF swf.101993.000001_tf_001.tf
+[INFO] Sent slice swf.101993.000001_slice_000.tf to queue
+[INFO] Received slice_result: slice_000 completed (success)
+```
+
+### Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Connection refused | ActiveMQ not running | Check `ACTIVEMQ_HOST` and `ACTIVEMQ_PORT` |
+| API errors | Monitor API unavailable | Verify `MONITOR_API_BASE_URL` |
+| No messages received | Wrong testbed namespace | Check `testbed.namespace` in config |
+| Import errors | Missing dependencies | Run `pip install -e .` in workspace root |
+
 ## See Also
 
 - [Agent Management](agent-management.md) - Starting and stopping agents

--- a/docs/fast-processing-workflow.md
+++ b/docs/fast-processing-workflow.md
@@ -407,7 +407,7 @@ Watch the console output for:
 | Issue | Cause | Solution |
 |-------|-------|----------|
 | Connection refused | ActiveMQ not running | Check `ACTIVEMQ_HOST` and `ACTIVEMQ_PORT` |
-| API errors | Monitor API unavailable | Verify `MONITOR_API_BASE_URL` |
+| API errors | Monitor API unavailable | Verify `SWF_MONITOR_URL` |
 | No messages received | Wrong testbed namespace | Check `testbed.namespace` in config |
 | Import errors | Missing dependencies | Run `pip install -e .` in workspace root |
 

--- a/example_agents/example_fastmon_agent.py
+++ b/example_agents/example_fastmon_agent.py
@@ -174,7 +174,8 @@ def main():
         "selection_fraction": 0.1,  # 10% of files
         # TF simulation parameters
         "tf_files_per_stf": 7,  # Number of TF files to generate per STF
-        "tf_size_fraction": 0.15,  # Fraction of STF size for each TF
+        "tf_size_fraction": 0.15,  # Fraction of partition TF count for each subsample (with gaussian noise)
+        "tf_count_per_stf": 1000,  # Default total TF count per STF if not provided in stf_ready message
         "tf_sequence_start": 1,  # Starting sequence number for TF files
     }
 

--- a/example_agents/example_fastmon_utils.py
+++ b/example_agents/example_fastmon_utils.py
@@ -69,12 +69,17 @@ def calculate_checksum(file_path: str, logger: logging.Logger) -> str:
 def simulate_tf_subsamples(stf_file: Dict[str, Any], config: dict, logger: logging.Logger, agent_name: str) -> List[Dict[str, Any]]:
     """
     Simulate creation of Time Frame (TF) subsamples from a Super Time Frame (STF) file.
-    
+
+    The total tf_count is split into tf_files_per_stf equal partitions. Within each
+    partition a contiguous block is sampled: size is tf_size_fraction * partition_width
+    with gaussian noise, and tf_first is chosen randomly within the valid range of the
+    partition. This guarantees no overlaps across subsample files.
+
     Args:
         stf_file: STF data dictionary (follows the keys from daq agent)
         config: Configuration dictionary
         logger: Logger instance
-        
+
     Returns:
         List of TF metadata dictionaries
     """
@@ -82,30 +87,34 @@ def simulate_tf_subsamples(stf_file: Dict[str, Any], config: dict, logger: loggi
         tf_files_per_stf = config.get("tf_files_per_stf", 2)
         tf_size_fraction = config.get("tf_size_fraction", 0.15)
         tf_sequence_start = config.get("tf_sequence_start", 1)
-        
+
+        tf_count = stf_file.get("tf_count") or config.get("tf_count_per_stf", 1000)
+        partition_width = tf_count // tf_files_per_stf
+
         tf_subsamples = []
-        stf_size = stf_file.get("size_bytes", 0)
-        if stf_size is None or stf_size <= 0:
-            logger.warning(f"STF file {stf_file.get('filename', 'unknown')} has invalid size_bytes: {stf_size}. Using default size of 0 for simulation.")
-            stf_size = 100
-        # filename without extension
         base_filename = stf_file.get("filename", "unknown").rsplit('.', 1)[0]
-        
+
         for i in range(tf_files_per_stf):
             sequence_number = tf_sequence_start + i
-            
-            # Generate TF filename based on STF filename
+            partition_start = i * partition_width
+            partition_end = partition_start + partition_width - 1 if i < tf_files_per_stf - 1 else tf_count - 1
+            partition_size = partition_end - partition_start + 1
+
+            subsample_size = max(1, min(int(partition_size * tf_size_fraction * random.gauss(1.0, 0.1)), partition_size))
+            max_start = partition_end - subsample_size + 1
+            tf_first = random.randint(partition_start, max_start) if max_start > partition_start else partition_start
+            tf_last = tf_first + subsample_size - 1
+
             tf_filename = f"{base_filename}_tf_{sequence_number:03d}.tf"
-            
-            # Calculate TF file size as fraction of STF size with some gaussian randomness
-            tf_size = int(stf_size * tf_size_fraction * random.gauss(1.0, 0.1))
-            
-            # Create TF metadata
+
             tf_metadata = {
                 "tf_filename": tf_filename,
-                "file_size_bytes": tf_size,
+                "tf_first": tf_first,
+                "tf_last": tf_last,
+                "tf_count": tf_last - tf_first + 1,
+                "file_size_bytes": subsample_size,
                 "sequence_number": sequence_number,
-                "stf_parent": stf_file.get("filename"),  # Use unique filename as parent identifier
+                "stf_parent": stf_file.get("filename"),
                 "metadata": {
                     "simulation": True,
                     "created_from": stf_file.get('filename'),
@@ -117,7 +126,7 @@ def simulate_tf_subsamples(stf_file: Dict[str, Any], config: dict, logger: loggi
                     "end": stf_file.get('end'),
                 }
             }
-            
+
             tf_subsamples.append(tf_metadata)
 
         return tf_subsamples
@@ -145,6 +154,9 @@ def record_tf_file(tf_metadata: Dict[str, Any], config: dict, agent, logger: log
         tf_file_data = {
             "stf_file": tf_metadata.get("stf_parent", None),  # STF filename as parent identifier
             "tf_filename": tf_metadata["tf_filename"],
+            "tf_first": tf_metadata["tf_first"],
+            "tf_last": tf_metadata["tf_last"],
+            "tf_count": tf_metadata["tf_count"],
             "file_size_bytes": tf_metadata["file_size_bytes"],
             "status": FileStatus.REGISTERED,
             "metadata": tf_metadata.get("metadata", {})
@@ -184,6 +196,9 @@ def create_tf_message(tf_file: Dict[str, Any], stf_file: Dict[str, Any], agent_n
         "processed_by": agent_name,
         "tf_file_id": tf_file.get('tf_file_id'),
         "tf_filename": tf_file.get('tf_filename'),
+        "tf_first": tf_file.get('tf_first'),
+        "tf_last": tf_file.get('tf_last'),
+        "tf_count": tf_file.get('tf_count'),
         "file_size_bytes": tf_file.get('file_size_bytes'),
         "stf_filename": stf_file.get('stf_filename') or stf_file.get('filename'),
         "status": tf_file.get('status'),

--- a/example_agents/example_fastmon_utils.py
+++ b/example_agents/example_fastmon_utils.py
@@ -85,6 +85,9 @@ def simulate_tf_subsamples(stf_file: Dict[str, Any], config: dict, logger: loggi
         
         tf_subsamples = []
         stf_size = stf_file.get("size_bytes", 0)
+        if stf_size is None or stf_size <= 0:
+            logger.warning(f"STF file {stf_file.get('filename', 'unknown')} has invalid size_bytes: {stf_size}. Using default size of 0 for simulation.")
+            stf_size = 100
         # filename without extension
         base_filename = stf_file.get("filename", "unknown").rsplit('.', 1)[0]
         

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -276,7 +276,7 @@ class FastProcessingAgent(BaseAgent):
                 destination=destination,
                 headers=stomp_headers
             )
-            logging.info(f"Sent message to '{destination}': {message_body}")
+            logging.info(f"Sent message to '{destination}' | headers={stomp_headers} | body={message_body}")
         except Exception as e:
             logging.error(f"Failed to send message to '{destination}': {e}")
             if any(t in str(e).lower() for t in ['ssl', 'eof', 'connection', 'broken pipe']):
@@ -290,7 +290,7 @@ class FastProcessingAgent(BaseAgent):
                             destination=destination,
                             headers=stomp_headers
                         )
-                        logging.info(f"Message sent after reconnection to '{destination}'")
+                        logging.info(f"Message sent after reconnection to '{destination}' | headers={stomp_headers} | body={message_body}")
                     except Exception as retry_e:
                         logging.error(f"Retry failed after reconnection: {retry_e}")
                 else:

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -435,7 +435,7 @@ class FastProcessingAgent(BaseAgent):
         slices_per_sample = fast_processing.get('slices_per_sample', 15)
 
         # Create TF slices from this STF sample
-        slices = self._create_tf_slices(stf_filename, slices_per_sample)
+        slices = self._create_tf_slices(tf_filename, slices_per_sample)
 
         # Push each slice to transformer queue
         for slice_data in slices:
@@ -654,7 +654,7 @@ class FastProcessingAgent(BaseAgent):
             tf_count = tf_last - tf_first + 1
 
             # Generate TF filename for this slice
-            tf_filename = f"{stf_filename.replace('.stf', '')}_slice_{i:03d}.tf"
+            tf_filename = f"{stf_filename.replace('.stf', '').replace('.tf', '')}_slice_{i:03d}.tf"
 
             slice_data = {
                 'slice_id': i,

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -387,7 +387,7 @@ class FastProcessingAgent(BaseAgent):
             })
 
             message = {
-                'msg_type': 'run_imminent',
+                'msg_type': 'run_imminent_worker',
                 'run_id': self.current_run_id,
                 'created_at': datetime.utcnow().isoformat(),
                 'content': content

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -223,6 +223,79 @@ class FastProcessingAgent(BaseAgent):
         except Exception as e:
             logging.error(f"Failed to register subscriber for {queue}: {e}")
 
+    def send_message(self, destination, message_body, headers=None):
+        """
+        Override BaseAgent.send_message to add optional STOMP headers support.
+
+        The base agent calls conn.send(body, destination) with no headers.
+        This override merges caller-supplied headers with sensible defaults and
+        passes them through to the broker.
+
+        Args:
+            destination: ActiveMQ destination ('/queue/...' or '/topic/...')
+            message_body: Dict to send as JSON. 'sender'/'namespace' auto-injected
+                          by the base class logic replicated here.
+            headers: Optional dict of additional STOMP headers, e.g.
+                     {'persistent': 'true', 'ttl': '43200000'}
+        """
+        if not destination.startswith('/queue/') and not destination.startswith('/topic/'):
+            raise ValueError(
+                f"destination must start with '/queue/' or '/topic/', got: '{destination}'. "
+                f"Use '/queue/{destination}' for anycast or '/topic/{destination}' for multicast."
+            )
+
+        # Mirror base agent: auto-inject sender and namespace
+        message_body['sender'] = self.agent_name
+        if self.namespace:
+            message_body['namespace'] = self.namespace
+        else:
+            logging.warning(
+                f"Sending message without namespace (msg_type={message_body.get('msg_type', 'unknown')}). "
+                "Configure namespace in testbed.toml to enable namespace filtering."
+            )
+
+        # Auto-inject created_at if not already set by the caller
+        if 'created_at' not in message_body:
+            message_body['created_at'] = datetime.utcnow().isoformat()
+
+        # Build STOMP headers: start with defaults, merge caller overrides on top
+        run_id = message_body.get('run_id') or self.current_run_id
+        stomp_headers = {
+            'persistent': 'false',
+            'vo': 'eic',
+            'msg_type': message_body.get('msg_type', 'unknown'),
+            'namespace': message_body.get('namespace', 'default'),
+            'run_id': str(run_id) if run_id else 'none',
+        }
+        if headers:
+            stomp_headers.update(headers)
+
+        try:
+            self.conn.send(
+                body=json.dumps(message_body),
+                destination=destination,
+                headers=stomp_headers
+            )
+            logging.info(f"Sent message to '{destination}': {message_body}")
+        except Exception as e:
+            logging.error(f"Failed to send message to '{destination}': {e}")
+            if any(t in str(e).lower() for t in ['ssl', 'eof', 'connection', 'broken pipe']):
+                logging.warning("Connection error detected - attempting recovery")
+                self.mq_connected = False
+                time.sleep(1)
+                if self._attempt_reconnect():
+                    try:
+                        self.conn.send(
+                            body=json.dumps(message_body),
+                            destination=destination,
+                            headers=stomp_headers
+                        )
+                        logging.info(f"Message sent after reconnection to '{destination}'")
+                    except Exception as retry_e:
+                        logging.error(f"Retry failed after reconnection: {retry_e}")
+                else:
+                    logging.error("Reconnection failed - message lost")
+
     def on_message(self, frame):
         """Handle incoming workflow messages."""
         message_data, msg_type = self.log_received_message(frame)
@@ -644,9 +717,17 @@ class FastProcessingAgent(BaseAgent):
             }
         }
 
-        # Send to transformer queue with required headers
+        # Send to transformer queue — persistent so slices survive broker restart,
+        # ttl of 12 hours so unprocessed slices are eventually discarded
         try:
-            self.send_message(self.TRANSFORMER_QUEUE, message)
+            self.send_message(
+                self.TRANSFORMER_QUEUE,
+                message,
+                headers={
+                    'persistent': 'true',
+                    'ttl': str(12 * 3600 * 1000)  # 12 hours in ms
+                }
+            )
 
             self.stats['slices_sent'] += 1
             self.logger.info(

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -380,6 +380,7 @@ class FastProcessingAgent(BaseAgent):
             content = dict(message_data or {})
             content.update({
                 'execution_id': self.current_execution_id,
+                'core_count': self.workflow_params.get("fast_processing", {}).get('target_worker_count', 1),
                 'target_worker_count': self.workflow_params.get("fast_processing", {}).get('target_worker_count', 1),
                 'slice_processing_time': self.workflow_params.get("fast_processing", {}).get('slice_processing_time', 1),
                 'worker_rampup_time': self.workflow_params.get("fast_processing", {}).get('worker_rampup_time', 1),

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -424,6 +424,9 @@ class FastProcessingAgent(BaseAgent):
         """
         tf_filename = message_data.get('tf_filename')
         stf_filename = message_data.get('stf_filename')
+        tf_first = message_data.get('tf_first', 0)
+        tf_last = message_data.get('tf_last')
+        tf_count = message_data.get('tf_count')
 
         self.stats['tf_files_received'] += 1
         self.tf_files_received += 1
@@ -431,12 +434,12 @@ class FastProcessingAgent(BaseAgent):
         self.logger.info(f"TF file registered: {tf_filename} (from STF: {stf_filename})",
                          extra=self._log_extra(tf_filename=tf_filename, stf_filename=stf_filename))
 
-        # Get slices_per_sample from workflow params
+        # Get num_tfs_per_slice from workflow params
         fast_processing = self.workflow_params.get('fast_processing', {})
-        slices_per_sample = fast_processing.get('slices_per_sample', 15)
+        num_tfs_per_slice = fast_processing.get('num_tfs_per_slice', 50)
 
-        # Create TF slices from this STF sample
-        slices = self._create_tf_slices(tf_filename, slices_per_sample)
+        # Create TF slices from this TF sample
+        slices = self._create_tf_slices(tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tfs_per_slice)
 
         # Push each slice to transformer queue
         for slice_data in slices:
@@ -637,32 +640,39 @@ class FastProcessingAgent(BaseAgent):
             self.logger.error(f"Error updating RunState slices: {e}",
                               extra=self._log_extra(error=str(e)))
 
-    def _create_tf_slices(self, stf_filename, num_slices):
+    def _create_tf_slices(self, tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tfs_per_slice):
         """
-        Create TF slice records in database.
+        Create TF slice records in database, based on the TF file's range [tf_first, tf_last].
+
+        Slices divide the TF file's range into chunks of num_tfs_per_slice TFs each.
+        Slice filenames are derived from tf_filename.
 
         Returns list of slice data dictionaries for sending to queue.
         """
+        import math
         slices = []
 
-        # Assume ~1000 TFs per STF, divide into num_slices
-        tfs_per_stf = 1000
-        tfs_per_slice = tfs_per_stf // num_slices
+        if tf_last is None or tf_count is None:
+            self.logger.error(f"Missing tf_last or tf_count for {tf_filename} — cannot create slices",
+                              extra=self._log_extra(tf_filename=tf_filename))
+            return slices
+
+        num_slices = math.ceil(tf_count / num_tfs_per_slice)
+        tf_base = tf_filename.rsplit('.', 1)[0]
 
         for i in range(num_slices):
-            tf_first = i * tfs_per_slice
-            tf_last = (i + 1) * tfs_per_slice - 1 if i < num_slices - 1 else tfs_per_stf - 1
-            tf_count = tf_last - tf_first + 1
+            slice_tf_first = tf_first + i * num_tfs_per_slice
+            slice_tf_last = min(slice_tf_first + num_tfs_per_slice - 1, tf_last)
+            slice_tf_count = slice_tf_last - slice_tf_first + 1
 
-            # Generate TF filename for this slice
-            tf_filename = f"{stf_filename.replace('.stf', '').replace('.tf', '')}_slice_{i:03d}.tf"
+            slice_filename = f"{tf_base}_slice_{i:03d}.tf"
 
             slice_data = {
                 'slice_id': i,
-                'tf_first': tf_first,
-                'tf_last': tf_last,
-                'tf_count': tf_count,
-                'tf_filename': tf_filename,
+                'tf_first': slice_tf_first,
+                'tf_last': slice_tf_last,
+                'tf_count': slice_tf_count,
+                'tf_filename': slice_filename,
                 'stf_filename': stf_filename,
                 'run_number': self.current_run_id,
                 'status': 'queued',
@@ -682,14 +692,14 @@ class FastProcessingAgent(BaseAgent):
                     # Add database ID to slice data for queue message
                     slice_data['db_id'] = result.get('id')
                     slices.append(slice_data)
-                    self.logger.debug(f"TFSlice created: {tf_filename}",
-                                      extra=self._log_extra(tf_filename=tf_filename))
+                    self.logger.debug(f"TFSlice created: {slice_filename}",
+                                      extra=self._log_extra(tf_filename=slice_filename))
                 else:
-                    self.logger.warning(f"Failed to create TFSlice: {tf_filename}",
-                                        extra=self._log_extra(tf_filename=tf_filename))
+                    self.logger.warning(f"Failed to create TFSlice: {slice_filename}",
+                                        extra=self._log_extra(tf_filename=slice_filename))
             except Exception as e:
-                self.logger.error(f"Error creating TFSlice {tf_filename}: {e}",
-                                  extra=self._log_extra(tf_filename=tf_filename, error=str(e)))
+                self.logger.error(f"Error creating TFSlice {slice_filename}: {e}",
+                                  extra=self._log_extra(tf_filename=slice_filename, error=str(e)))
 
         return slices
 

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -12,8 +12,14 @@ Pipeline: FastMon Agent [tf_file_registered] -> Fast Processing Agent [TF slices
 Message format specification: https://github.com/wguanicedew/iDDS/blob/dev/main/prompt.md
 """
 
+import signal
+import time
+import logging
+import traceback
+import json
 import uuid
 from datetime import datetime
+import stomp
 from swf_common_lib.base_agent import BaseAgent
 
 
@@ -37,10 +43,12 @@ class FastProcessingAgent(BaseAgent):
     def __init__(self, debug=False, config_path=None):
         super().__init__(
             agent_type='Fast_Processing',
-            subscription_queues=['/topic/epictopic', self.TRANSFORMER_RESULTS_QUEUE],
+            subscription_queue='/topic/epictopic',
             debug=debug,
             config_path=config_path
         )
+        # Additional subscriptions beyond the primary queue (subscribed in run())
+        self._extra_subscription_queues = [self.TRANSFORMER_RESULTS_QUEUE]
 
         # Workflow parameters (populated on run_imminent)
         self.workflow_params = {}
@@ -58,6 +66,162 @@ class FastProcessingAgent(BaseAgent):
             'results_done': 0,
             'results_failed': 0
         }
+
+    def run(self):
+        """
+        Override run() to subscribe to both the workflow topic and the
+        transformer results queue before entering the main loop.
+        """
+        def signal_handler(signum, frame):
+            sig_name = signal.Signals(signum).name
+            logging.info(f"Received {sig_name}, initiating graceful shutdown...")
+            raise KeyboardInterrupt(f"Received {sig_name}")
+
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGQUIT, signal_handler)
+
+        logging.info(f"Starting {self.agent_name}...")
+
+        # Connect to ActiveMQ
+        if not getattr(self, 'mq_connected', False):
+            max_retries = 3
+            retry_delay = 5
+            for attempt in range(1, max_retries + 1):
+                logging.info(f"Connecting to ActiveMQ at {self.mq_host}:{self.mq_port} (attempt {attempt}/{max_retries})")
+                try:
+                    self.conn.connect(
+                        self.mq_user,
+                        self.mq_password,
+                        wait=True,
+                        version='1.1',
+                        headers={
+                            'client-id': self.agent_name,
+                            'heart-beat': '30000,30000'
+                        }
+                    )
+                    self.mq_connected = True
+                    break
+                except Exception as e:
+                    logging.warning(f"Connection attempt {attempt} failed: {e}")
+                    if attempt < max_retries:
+                        logging.info(f"Retrying in {retry_delay} seconds...")
+                        time.sleep(retry_delay)
+                    else:
+                        logging.error(f"Failed to connect after {max_retries} attempts")
+                        raise
+
+        try:
+            # Subscribe to primary workflow topic
+            self.conn.subscribe(destination=self.subscription_queue, id=1, ack='auto')
+            logging.info(f"Subscribed to queue: '{self.subscription_queue}'")
+
+            # Subscribe to all extra queues (e.g. transformer results)
+            for idx, queue in enumerate(self._extra_subscription_queues, start=2):
+                self.conn.subscribe(destination=queue, id=idx, ack='auto')
+                logging.info(f"Subscribed to queue: '{queue}'")
+
+            # Register all subscriptions in monitor
+            self._register_subscribers()
+
+            # Agent is now ready and waiting for work
+            self.set_ready()
+
+            self.send_heartbeat()
+
+            logging.info(f"{self.agent_name} is running. Press Ctrl+C to stop.")
+            while True:
+                time.sleep(60)
+                if not self.mq_connected:
+                    self._attempt_reconnect()
+                self.send_heartbeat()
+
+        except KeyboardInterrupt:
+            logging.info(f"Stopping {self.agent_name}...")
+        except stomp.exception.ConnectFailedException as e:
+            self.mq_connected = False
+            logging.error(f"Failed to connect to ActiveMQ: {e}")
+            logging.error("Please check the connection details and ensure ActiveMQ is running.")
+        except Exception as e:
+            self.mq_connected = False
+            logging.error(f"An unexpected error occurred: {e}")
+            traceback.print_exc()
+        finally:
+            try:
+                self.operational_state = 'EXITED'
+                self.send_heartbeat()
+            except Exception:
+                pass
+            try:
+                if self.mq_connected:
+                    self.conn.disconnect()
+            except Exception:
+                pass
+
+    def _attempt_reconnect(self):
+        """
+        Override _attempt_reconnect to resubscribe to all queues
+        (primary + extra) after reconnection.
+        """
+        if self.mq_connected:
+            return True
+
+        try:
+            logging.info("Attempting to reconnect to ActiveMQ...")
+            if self.conn.is_connected():
+                self.conn.disconnect()
+
+            self.conn.connect(
+                self.mq_user,
+                self.mq_password,
+                wait=True,
+                version='1.1',
+                headers={
+                    'client-id': self.agent_name,
+                    'heart-beat': '30000,30000'
+                }
+            )
+
+            # Resubscribe to primary queue
+            self.conn.subscribe(destination=self.subscription_queue, id=1, ack='auto')
+            logging.info(f"Resubscribed to queue: '{self.subscription_queue}'")
+
+            # Resubscribe to all extra queues
+            for idx, queue in enumerate(self._extra_subscription_queues, start=2):
+                self.conn.subscribe(destination=queue, id=idx, ack='auto')
+                logging.info(f"Resubscribed to queue: '{queue}'")
+
+            self.mq_connected = True
+            logging.info("Successfully reconnected to ActiveMQ")
+            return True
+
+        except Exception as e:
+            logging.warning(f"Reconnection attempt failed: {e}")
+            self.mq_connected = False
+            return False
+
+    def _register_subscribers(self):
+        """Register all subscriptions (primary + extra) in the monitor."""
+        all_queues = [self.subscription_queue] + self._extra_subscription_queues
+        for queue in all_queues:
+            self._register_single_subscriber(queue)
+
+    def _register_single_subscriber(self, queue):
+        """Register a single subscription in the monitor API."""
+        subscriber_data = {
+            'subscriber_name': f"{self.agent_name}-{queue}",
+            'description': f"{self.agent_type} agent subscribing to {queue}",
+            'is_active': True,
+            'fraction': 1.0
+        }
+        try:
+            result = self._api_request('post', '/subscribers/', subscriber_data)
+            if result:
+                if result.get('status') == 'already_exists':
+                    logging.info(f"Subscriber already registered: {subscriber_data['subscriber_name']}")
+                else:
+                    logging.info(f"Subscriber registered: {subscriber_data['subscriber_name']}")
+        except Exception as e:
+            logging.error(f"Failed to register subscriber for {queue}: {e}")
 
     def on_message(self, frame):
         """Handle incoming workflow messages."""
@@ -88,7 +252,6 @@ class FastProcessingAgent(BaseAgent):
         except Exception as e:
             self.logger.error(f"Error processing {msg_type}: {e}",
                               extra=self._log_extra(error=str(e)))
-            import traceback
             self.logger.error(traceback.format_exc())
 
     def _update_run_context(self, message_data):
@@ -108,7 +271,10 @@ class FastProcessingAgent(BaseAgent):
             self.stats = {
                 'tf_files_received': 0,
                 'slices_created': 0,
-                'slices_sent': 0
+                'slices_sent': 0,
+                'results_received': 0,
+                'results_done': 0,
+                'results_failed': 0
             }
 
         if execution_id and execution_id != self.current_execution_id:
@@ -117,7 +283,6 @@ class FastProcessingAgent(BaseAgent):
             if not self.workflow_params:
                 self.workflow_params = self._fetch_workflow_parameters(execution_id)
                 if self.workflow_params:
-                    import json
                     self.logger.info(f"Workflow parameters loaded (mid-run): {json.dumps(self.workflow_params, indent=2, sort_keys=True)}")
 
     def handle_run_imminent(self, message_data):
@@ -157,9 +322,7 @@ class FastProcessingAgent(BaseAgent):
 
             # Topic for worker broadcasts
             worker_topic = self.WORKER_BROADCAST_TOPIC
-
-            headers = {'persistent': 'false'}
-            self.send_message(worker_topic, message, headers=headers)
+            self.send_message(worker_topic, message)
 
             self.logger.info(f"Broadcasted run_imminent to workers: {worker_topic}",
                              extra=self._log_extra(destination=worker_topic))
@@ -277,9 +440,7 @@ class FastProcessingAgent(BaseAgent):
             }
 
             worker_topic = self.WORKER_BROADCAST_TOPIC
-
-            headers = {'persistent': 'false'}
-            self.send_message(worker_topic, message, headers=headers)
+            self.send_message(worker_topic, message)
 
             self.logger.info(f"Broadcasted end_run to workers: {worker_topic}",
                              extra=self._log_extra(destination=worker_topic))
@@ -485,12 +646,7 @@ class FastProcessingAgent(BaseAgent):
 
         # Send to transformer queue with required headers
         try:
-            # Use send_message with persistent=True and ttl for slice messages
-            headers = {
-                'persistent': 'true',
-                'ttl': str(12 * 3600 * 1000)  # 12 hours in ms
-            }
-            self.send_message(self.TRANSFORMER_QUEUE, message, headers=headers)
+            self.send_message(self.TRANSFORMER_QUEUE, message)
 
             self.stats['slices_sent'] += 1
             self.logger.info(

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -434,12 +434,12 @@ class FastProcessingAgent(BaseAgent):
         self.logger.info(f"TF file registered: {tf_filename} (from STF: {stf_filename})",
                          extra=self._log_extra(tf_filename=tf_filename, stf_filename=stf_filename))
 
-        # Get num_tfs_per_slice from workflow params
+        # Get num_tf_per_slice from workflow params
         fast_processing = self.workflow_params.get('fast_processing', {})
-        num_tfs_per_slice = fast_processing.get('num_tfs_per_slice', 50)
+        num_tf_per_slice = fast_processing.get('num_tf_per_slice', 2)
 
         # Create TF slices from this TF sample
-        slices = self._create_tf_slices(tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tfs_per_slice)
+        slices = self._create_tf_slices(tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tf_per_slice)
 
         # Push each slice to transformer queue
         for slice_data in slices:
@@ -640,11 +640,11 @@ class FastProcessingAgent(BaseAgent):
             self.logger.error(f"Error updating RunState slices: {e}",
                               extra=self._log_extra(error=str(e)))
 
-    def _create_tf_slices(self, tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tfs_per_slice):
+    def _create_tf_slices(self, tf_filename, stf_filename, tf_first, tf_last, tf_count, num_tf_per_slice):
         """
         Create TF slice records in database, based on the TF file's range [tf_first, tf_last].
 
-        Slices divide the TF file's range into chunks of num_tfs_per_slice TFs each.
+        Slices divide the TF file's range into chunks of num_tf_per_slice TFs each.
         Slice filenames are derived from tf_filename.
 
         Returns list of slice data dictionaries for sending to queue.
@@ -657,12 +657,12 @@ class FastProcessingAgent(BaseAgent):
                               extra=self._log_extra(tf_filename=tf_filename))
             return slices
 
-        num_slices = math.ceil(tf_count / num_tfs_per_slice)
+        num_slices = math.ceil(tf_count / num_tf_per_slice)
         tf_base = tf_filename.rsplit('.', 1)[0]
 
         for i in range(num_slices):
-            slice_tf_first = tf_first + i * num_tfs_per_slice
-            slice_tf_last = min(slice_tf_first + num_tfs_per_slice - 1, tf_last)
+            slice_tf_first = tf_first + i * num_tf_per_slice
+            slice_tf_last = min(slice_tf_first + num_tf_per_slice - 1, tf_last)
             slice_tf_count = slice_tf_last - slice_tf_first + 1
 
             slice_filename = f"{tf_base}_slice_{i:03d}.tf"

--- a/example_agents/fast_processing_agent.py
+++ b/example_agents/fast_processing_agent.py
@@ -531,6 +531,7 @@ class FastProcessingAgent(BaseAgent):
 
     def handle_slice_result(self, message_data):
         """Process slice_result messages from transformer workers."""
+        logging.info(f"Received slice_result message: {message_data}")
         self.stats['results_received'] += 1
 
         content = message_data.get('content', {})

--- a/workflows/workflow_runner.py
+++ b/workflows/workflow_runner.py
@@ -509,8 +509,9 @@ class WorkflowRunner(BaseAgent):
                 return
             workflow_definition_id = results[0]['id']
 
-        # Get namespace from testbed config and ensure it exists in database
-        namespace = config.get('testbed', {}).get('namespace')
+        # Get namespace from workflow config and ensure it exists in database
+        workflow_config = self._load_workflow_config(workflow_name)
+        namespace = workflow_config.get('testbed', {}).get('namespace') or config.get('testbed', {}).get('namespace')
         if namespace:
             try:
                 ensure_namespace(self.monitor_url, self.api_session, namespace, logger=self.logger)

--- a/workflows/workflow_runner.py
+++ b/workflows/workflow_runner.py
@@ -509,9 +509,8 @@ class WorkflowRunner(BaseAgent):
                 return
             workflow_definition_id = results[0]['id']
 
-        # Get namespace from workflow config and ensure it exists in database
-        workflow_config = self._load_workflow_config(workflow_name)
-        namespace = workflow_config.get('testbed', {}).get('namespace') or config.get('testbed', {}).get('namespace')
+        # Get namespace from testbed config and ensure it exists in database
+        namespace = config.get('testbed', {}).get('namespace')
         if namespace:
             try:
                 ensure_namespace(self.monitor_url, self.api_session, namespace, logger=self.logger)


### PR DESCRIPTION
1) add docs about fast processing agent
2) make fast processing agent be able to subscribe more than one topic/queue. Because it needs to subscribe at least epictopic for inputs and panda.requests for recording the processing status.
3) use tf_count to sample files in fastmon agent
4) use tf file (tf_count, tf_first, tf_last) to create sliced in fast processing agent