### PR TITLE
Avoid using the same /tmp/swf-agents-supervisor.sock

### DIFF
--- a/agents.supervisord.conf
+++ b/agents.supervisord.conf
@@ -3,7 +3,7 @@
 ; Agents start on demand via 'testbed run', not automatically
 
 [unix_http_server]
-file=/tmp/swf-agents-supervisor.sock
+file=/tmp/swf-agents-supervisor-%(ENV_USER).sock
 
 [supervisord]
 logfile=%(here)s/logs/agents-supervisord.log
@@ -17,7 +17,7 @@ minprocs=200
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///tmp/swf-agents-supervisor.sock
+serverurl=unix:///tmp/swf-agents-supervisor-%(ENV_USER).sock
 
 ; =============================================================================
 ; Example Agents - start on demand, not automatically


### PR DESCRIPTION
Supervisord doesn't start if another user created the socket
```
write(2, "Unlinking stale socket /tmp/swf-"..., 55) = 55
unlink("/tmp/swf-agents-supervisor.sock") = -1 EPERM (Operation not permitted)
```