### PR TITLE
v37 baseline — first end-to-end automated production pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ daq_events/
 .Trashes
 ehthumbs.db
 Thumbs.db
+# Rendered SVG->PNG diagram artifacts (curated images live in docs/images/ and images/)
+docs/*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+Official system-level documentation for the ePIC WFMS (the testbed is its streaming front):
+<https://epic-wfms-docs.readthedocs.io> (workspace repo `epic-wfms-docs/`).
+
 ## Essential Commands
 
 ```bash
@@ -27,7 +30,7 @@ swf_list_logs(execution_id='...')         # Workflow logs
 
 ## Project-Specific Rules
 
-**Branch:** All 3 repos must be on `infra/baseline-v34`
+**Branch:** All 3 repos must be on the latest `infra/baseline-vNN` — the current baseline branch is always the working branch
 
 **First push:** `git push -u origin branch-name` sets up tracking.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is the umbrella repository for the ePIC streaming workflow testbed.
 
 ## Documentation
 
+- [**ePIC WFMS Documentation**](https://epic-wfms-docs.readthedocs.io) - Official system-level documentation for the ePIC Workflow Management System, of which the testbed is the streaming implementation front
+
 ### Release Notes
 - [**Release Notes**](RELEASE_NOTES.md) - What's new in each version
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -159,7 +159,7 @@ The streaming `/swf-monitor/mcp/` endpoint (isolated on its own ASGI worker in v
 
 ### PanDAbot (swf-monitor)
 
-- **Corun completion notifications** integrated; bot commentary on a job routes to the originating Mattermost thread rather than the channel.
+- **corun-ai completion notifications** integrated; bot commentary on a job routes to the originating Mattermost thread rather than the channel.
 - **DID-specific Rucio rule lookup** so a question about a specific dataset finds its replication rules without an LLM tool-search round trip.
 - **Reply discipline.** Direct `@PanDAbot` mentions now require a substantive reply (silence-only variants are flagged). Plain channel chatter no longer reaches Haiku. ePIC campaign Rucio scope handling fixed.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,90 @@
 # Release Notes
 
+## v37 (2026-07-10)
+
+This baseline completes the first end-to-end pass of ePIC automated production. A production request enters through deterministic intake — the new request composer (part of this release) or automated import from the existing questionnaire — rather than a hand-tended spreadsheet; PCS composes it into configured tasks; a continuum of campaign catalogs map to ePIC's monthly cadence; the production operations agent submits to PanDA and records each physical attempt; produced data is reconciled from Rucio back onto the campaign catalog; and campaign succession runs as a reviewed AI proposal set — an LLM digests the production meeting record and drafts the disposition set that seeds the next campaign, with an operator approving every disposition. The connective tissue — structured action logging, live policy, alarms, narratives — is also here.
+
+### The Campaign Continuum (swf-monitor)
+
+One curated catalog now spans every campaign, with lifecycle as an attribute rather than separate views:
+
+- **Physics configurations and editions**: the campaign-invariant identity behind dataset editions (physics tag + evgen identity + background + sample variant) is resolved by a dedicated module with a never-guess policy — where a bound tag and the observed path conflict, the path wins and the edition is flagged; unresolved configurations can never falsely merge.
+- **Campaign instancing**: a plan/execute step mints the next campaign's editions from the current catalog, honoring per-configuration dispositions, with a review panel on the producing tab and truthful post-run reporting. Disposition resolution is configuration-wide, not per-row.
+- **Propagation dispositions**: continue / hold / final per physics configuration, recommendations by AI based on plan analysis but flipped only by humans, each flip carrying a required comment into an append-only history; bulk catalog action with badges on non-continue rows.
+- **Requests over physics configurations**: production requests bind to the configuration identity and project onto campaign editions, imported and composed requests alike.
+- **Lifecycle surfaces**: a symmetric tab strip over past / last / current / producing / future; producing is derived from live Rucio arrivals, never stored; one-click promote rotation; the future tab detects the coming campaign from pending disposition batches (as determined from e.g. the LLM analyzing presentations at Physics, S&C planning meetings, as in the case of the July 8 meeting) and applies the instancing treatment on detection.
+- **Firsthand Rucio reconciliation**: a producing campaign's records track Rucio directly — known DIDs refresh counts and replica status, unknown DIDs resolve to physics configurations before any row is created; the arrivals sweep watches all campaigns with one shallow query per root, and the past-campaign ingest runs as a nightly chain step.
+- **Edition data pages**: every physics configuration navigates to its per-campaign Rucio data — real DIDs, files, volume, per-RSE replica status — linked from the catalog, the compose view, and the physics-configuration view.
+
+### AI Proposals (swf-monitor)
+
+The AI proposal subsystem is v1-complete and campaign succession is its first production use: the LLM proposes, a human decides, execution is deterministic.
+
+- `src/ai/` is a first-class Django app with a canonical proposal ledger, queue page, and stable references (`cp-N`) usable from the bot MCP surface.
+- The catalog is a first-class decision site: proposal blocks on the compose detail, left-panel badges, decision quality recorded on approval, and an undo verb that returns a row to pending with an unwind-complete record.
+- AI presence follows one visual convention — bordered lavender blocks, purple titles only on AI pages — and the AI marker follows the voice of the artifact, not its authorship.
+
+### Campaign Narratives (swf-monitor)
+
+Campaign narratives are the human record of each campaign's intent and outcome: a collapsible narratives page with detail pages, comments, expert editing in the house style, a publish control, and a version lifecycle replacing draft/locked. Conventions are documented in `EPICPROD_NARRATIVES.md`. These may be created by LLMs, as in July, when an LLM analyzed presentations at the July 8 PS&C meeting and produced general and 26.07 specific campaign narratives which will guide automated daily and weekly assessments of the campaign.
+
+### The epicprod Action Stream (swf-monitor)
+
+Every substantive epicprod action — agent handler, MCP tool, web-tier operation — now records one structured record with outcome, duration, requesting user, and failure reason, giving the system a single operational memory:
+
+- **Sublevel and live axes**: each action declares its importance and live-stream recommendation; the effective live policy is a SysConfig override editable on the live-policy page; the Logs page carries the live stream view, importance thresholds, and user/instance/module filters.
+- **SysConfig**: database-backed system configuration with a System-page editor; reads are read-or-seed, so every key is visible at its default — no hidden knobs.
+- **Nightly catalog sync**: a cron-enqueued chain — CSV import, questionnaire import, association sweep with auto-intake of direct `group.EIC` submissions (adopted tasks, the standing born-vs-adopted migration metric), Rucio output snapshot, EVGEN assimilation, questionnaire automatch, match cache, progress refresh — each step logged with measured durations.
+- **Questionnaire automatch**: standing LLM matching of requests to tasks with batched calls, an exact-beam rule enforced in code, and event-driven rescans.
+- **Alarms on the stream**: catalog-sync freshness and payload-fetch-rate alarms; alarm email moved to the BNL SMTP relay.
+- **epicprod-live Mattermost publisher** posting as a dedicated bot account, and the PanDA bot renamed to DISpatcher (the ePIC-chosen name) with an expanded MCP tool admission list.
+
+### Production Request Composer (swf-monitor)
+
+`/pcs/request/` is the native production-request intake on the path to replacing the Google Form. A requester describes the physics in plain terms and the page shows, live, the matching configurations the system already has — adopting one records the same configuration anchor the CSV import writes. PWG and DSC are distinct fields carrying the official collaboration lists (the five physics working groups; the fifteen detector subsystem collaborations, grouped by region) with an Other escape; contact fields prefill from real user data; submission is external-safe through the devcloud proxy and gated by login. The composer is also the first "my epicprod" surface: a signed-in user's previous requests are the starting point for the next one.
+
+### PanDA Task Operations and Job Diagnosis (swf-monitor)
+
+- Physical PanDA attempts are first-class: `PandaTasks` records every submission, `.tryN` names give each whole-task rerun its own PanDA task and Rucio namespace, and the compose page exposes the three native operations — add another retry, restart-and-retry failures, rerun entire task — gated by PanDA task state.
+- Job pages gained a study action with cached diagnosis; ePIC production job diagnosis surfaces in the task job list; payload logs are fetched before study and `.tryN` propagates to payload outputs.
+- Task and job parameter rendering was cleaned throughout: linked URL parameters, text-view transpath links, content-sized tables, zero counts without state color.
+
+### AI Assessments (swf-monitor)
+
+Append-only AI assessments extend to production campaigns as a subject type, are stored as corun-ai artifacts with the local mechanism retained for migration, and carry review comments and quality metadata with standard retrieval through MCP.
+
+### Platform and Operations (swf-monitor)
+
+- **SSE serves from the ASGI worker** — the durable fix for the pinned-worker 503 outages; long-held streams no longer occupy mod_wsgi workers.
+- **Nightly swfdb backup** with built-in integrity verification.
+- **Catalog page-load containment**: the current-campaign table, campaign progress, and questionnaire matches are cached with nightly rebuild and activity-triggered refresh; page-load work is instrumented and bounded.
+- **Deployment**: the lightweight deploy covers the ai app; the full deploy restarts the prod-ops agent; a pre-commit checks script encodes the compile/system-check/template-lint gate.
+
+### UI Standards (swf-monitor)
+
+- One button-role convention everywhere: solid variants act, outlines are reserved for stateful toggles.
+- Operator actions are visible but inactive for non-operator viewers — every viewer sees what operators can do.
+- Timestamps display in Eastern time throughout; editors fit the visible window; dropdown group headers render high-contrast in any browser theme.
+- Generators display in their authors' spelling (BeAGLE, EpIC); Q² range labels parse in both the `1to10` and `1_10` spellings by value.
+
+### Documentation and Diagrams (swf-monitor)
+
+- New diagrams: the epicprod system overview, the operations automation loop, and the action stream.
+- README, CLAUDE.md, and PCS.md point to the official ePIC WFMS documentation (<https://epic-wfms-docs.readthedocs.io>); the external-access contract now states the proxy catch-all reality; corun-ai naming is used throughout.
+
+### swf-testbed
+
+- Documentation points to the official WFMS documentation; the baseline branch reference is version-free; an E0–E1 workflow schematic was added.
+- Folded in from main (merged during the cycle): integration-test refactor into a `workflow_call` with explicit per-repo checkout and CI on the baseline branch, `data_agent` rucio_comms cleanup, STF-file status polling in the prompt-processing workflow with configurable interval and timeout, processing STF files no longer reclaimed, and user-testbed start for prompt processing via MCP.
+
+### swf-common-lib
+
+- README points to the official WFMS documentation.
+
+### Acknowledgments
+
+Direct-to-main contributions folded into this baseline: **Dmitry Kalinkin** (integration-test `workflow_call` refactor, explicit checkout repos, `data_agent` cleanup, CI on the baseline branch) and **Zhaoyu Yang** (STF-status polling in prompt processing, processing-file reclaim fix, MCP user-testbed start).
+
 ## v36 (2026-06-21)
 
 ### EpicProd Production Workflow Shell (swf-monitor)

--- a/docs/E0-E1_workflow_schematic.svg
+++ b/docs/E0-E1_workflow_schematic.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1220 620" font-family="Arial, Helvetica, sans-serif">
+
+  <rect width="1220" height="620" fill="#ffffff"/>
+
+  <!-- ===== Facilities: common bottom edge at y=292 ===== -->
+  <rect x="360" y="12" width="852" height="280" fill="#fce5cd" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="604" y="44" font-size="25" font-weight="bold" fill="#000">BNL data center</text>
+
+  <rect x="580" y="332" width="632" height="280" fill="#fce5cd" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="604" y="598" font-size="25" font-weight="bold" fill="#000">JLab data center</text>
+
+  <rect x="8" y="12" width="260" height="280" fill="#a8b4e4" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="22" y="44" font-size="26" font-weight="bold" fill="#17365d">IP6</text>
+
+  <!-- ===== DAQ system: one system spanning both facilities, flush with facility bottoms ===== -->
+  <rect x="48" y="76" width="220" height="216" fill="#5f85c8" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="60" y="104" font-size="19" font-weight="bold" fill="#ffffff">DAQ room</text>
+
+  <rect x="360" y="76" width="124" height="216" fill="#5f85c8" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="422" y="104" font-size="18" font-weight="bold" fill="#ffffff" text-anchor="middle">DAQ enclave</text>
+
+  <!-- 4Tbps connector between the facilities, inside the DAQ system boundary -->
+  <line x1="268" y1="210" x2="360" y2="210" stroke="#3a62a8" stroke-width="7"/>
+  <text x="314" y="196" font-size="17" font-weight="bold" fill="#17365d" text-anchor="middle">4Tbps</text>
+
+  <!-- thick blue boundary around the whole DAQ system -->
+  <rect x="50.5" y="78.5" width="431" height="211" fill="none" stroke="#3a62a8" stroke-width="5"/>
+
+  <!-- Exit buffer: ONE buffer spanning the enclave edge; outer face is what the E1 world sees -->
+  <rect x="372" y="168" width="224" height="112" fill="#9fb4de" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="428" y="204" font-size="18" fill="#17365d" text-anchor="middle">STF buffer</text>
+  <text x="428" y="228" font-size="18" fill="#17365d" text-anchor="middle">(72hr</text>
+  <text x="428" y="252" font-size="18" fill="#17365d" text-anchor="middle">depth)</text>
+  <text x="540" y="204" font-size="18" fill="#17365d" text-anchor="middle">Ext subnet</text>
+  <text x="540" y="228" font-size="18" fill="#17365d" text-anchor="middle">for E1</text>
+  <text x="540" y="252" font-size="18" fill="#17365d" text-anchor="middle">delivery</text>
+
+  <!-- Echelon 0: exactly the width of the DAQ system -->
+  <rect x="48" y="300" width="436" height="38" fill="#4472c4" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="266" y="325" font-size="20" font-weight="bold" fill="#ffffff" text-anchor="middle">Echelon 0</text>
+
+  <!-- ===== ePIC Echelon 1 at BNL: centered in facility (y 20..284), uniform 12px interior margins ===== -->
+  <rect x="816" y="20" width="388" height="264" fill="#a9d18e" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="1010" y="46" font-size="22" font-weight="bold" fill="#000" text-anchor="middle">ePIC Echelon 1 at BNL</text>
+
+  <line x1="913" y1="104" x2="913" y2="152" stroke="#538135" stroke-width="2"/>
+  <line x1="998" y1="156" x2="1020" y2="156" stroke="#538135" stroke-width="2"/>
+  <line x1="998" y1="192" x2="1020" y2="192" stroke="#538135" stroke-width="2"/>
+
+  <rect x="828" y="56" width="170" height="48" fill="#578b3f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="913" y="86" font-size="18" fill="#000" text-anchor="middle">Archive</text>
+
+  <rect x="828" y="152" width="170" height="80" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="913" y="198" font-size="18" fill="#000" text-anchor="middle">Buffer</text>
+
+  <rect x="1020" y="112" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="142" font-size="18" fill="#000" text-anchor="middle">Prompt processing</text>
+
+  <rect x="1020" y="168" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="198" font-size="18" fill="#000" text-anchor="middle">Prompt monitoring</text>
+
+  <rect x="1020" y="224" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="254" font-size="18" fill="#000" text-anchor="middle">Fast monitoring</text>
+
+  <!-- ===== ePIC Echelon 1 at JLab: centered in facility (y 340..604), mirror layout ===== -->
+  <rect x="816" y="340" width="388" height="264" fill="#a9d18e" stroke="#1a1a1a" stroke-width="1.2"/>
+  <text x="1010" y="592" font-size="22" font-weight="bold" fill="#000" text-anchor="middle">ePIC Echelon 1 at JLab</text>
+
+  <line x1="998" y1="432" x2="1020" y2="432" stroke="#538135" stroke-width="2"/>
+  <line x1="998" y1="468" x2="1020" y2="468" stroke="#538135" stroke-width="2"/>
+  <line x1="913" y1="472" x2="913" y2="520" stroke="#538135" stroke-width="2"/>
+
+  <rect x="1020" y="352" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="382" font-size="18" fill="#000" text-anchor="middle">Fast monitoring</text>
+
+  <rect x="1020" y="408" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="438" font-size="18" fill="#000" text-anchor="middle">Prompt processing</text>
+
+  <rect x="1020" y="464" width="172" height="48" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="1106" y="494" font-size="18" fill="#000" text-anchor="middle">Prompt monitoring</text>
+
+  <rect x="828" y="392" width="170" height="80" fill="#6aa84f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="913" y="438" font-size="18" fill="#000" text-anchor="middle">Buffer</text>
+
+  <rect x="828" y="520" width="170" height="48" fill="#578b3f" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="913" y="550" font-size="18" fill="#000" text-anchor="middle">Archive</text>
+
+  <!-- ===== Streams ===== -->
+  <!-- STF stream: exit buffer -> BNL switch -> E1 Buffer -->
+  <line x1="596" y1="200" x2="716" y2="200" stroke="#a64d79" stroke-width="5"/>
+  <line x1="782" y1="200" x2="828" y2="200" stroke="#a64d79" stroke-width="5"/>
+  <text x="656" y="176" font-size="14" font-weight="bold" fill="#a64d79" text-anchor="middle">STF stream</text>
+  <text x="656" y="192" font-size="13" fill="#a64d79" text-anchor="middle">(Rucio)</text>
+
+  <!-- TF stream: exit buffer -> BNL switch -> Fast monitoring -->
+  <line x1="596" y1="250" x2="716" y2="250" stroke="#a64d79" stroke-width="2.5"/>
+  <line x1="782" y1="250" x2="1020" y2="250" stroke="#a64d79" stroke-width="2.5"/>
+  <text x="656" y="226" font-size="14" fill="#a64d79" text-anchor="middle">TF stream</text>
+  <text x="656" y="242" font-size="12" fill="#a64d79" text-anchor="middle">(Message/XRootD)</text>
+
+  <!-- 400Gbps via ESnet: BNL switch down to JLab switch -->
+  <line x1="749" y1="270" x2="749" y2="356" stroke="#a64d79" stroke-width="5"/>
+  <text x="737" y="318" font-size="15" fill="#a64d79" text-anchor="end">400Gbps via ESnet</text>
+
+  <!-- JLab switch -> Fast monitoring, -> Buffer -->
+  <line x1="782" y1="376" x2="1020" y2="376" stroke="#a64d79" stroke-width="2.5"/>
+  <line x1="782" y1="426" x2="828" y2="426" stroke="#a64d79" stroke-width="5"/>
+
+  <!-- ===== Switches ===== -->
+  <rect x="716" y="170" width="66" height="100" fill="#c27ba0" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="749" y="226" font-size="16" fill="#000" text-anchor="middle">Switch</text>
+
+  <rect x="716" y="356" width="66" height="100" fill="#c27ba0" stroke="#1a1a1a" stroke-width="1"/>
+  <text x="749" y="412" font-size="16" fill="#000" text-anchor="middle">Switch</text>
+
+  <!-- ===== Testbed scope delineation: everything right of the red line ===== -->
+  <line x1="490.5" y1="46" x2="490.5" y2="430" stroke="#c00000" stroke-width="7"/>
+  <line x1="493" y1="393" x2="529" y2="393" stroke="#c00000" stroke-width="10"/>
+  <polygon points="529,379 547,393 529,407" fill="#c00000"/>
+  <text x="470" y="385" font-size="22" font-weight="bold" fill="#c00000" text-anchor="end">Streaming workflow testbed</text>
+  <text x="470" y="413" font-size="22" font-weight="bold" fill="#c00000" text-anchor="end">scope is right of red line</text>
+
+</svg>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ System design and components of the SWF Testbed.
 The testbed plan is based on ePIC streaming computing model WG discussions
 in the streaming computing model meeting[^1], guided by the ePIC streaming
 computing model report[^2], and the ePIC workflow management system
-requirements draft[^3].
+requirements[^3].
 
 ## Testbed plan
 
@@ -259,7 +259,7 @@ graph LR
 
 [^2]: [ePIC streaming computing model report](https://zenodo.org/records/14675920)
 
-[^3]: [ePIC workflow management system requirements draft](https://docs.google.com/document/d/1OmAGzFgZgEP6ntuRkP51kiOqF_0uh_RPjq8wgdTwb2A/edit?tab=t.0#heading=h.g1vlz8vqp7ht)
+[^3]: [ePIC workflow management system requirements](https://www.overleaf.com/project/67bdf89a3d44a138da503dea)
 
 [^4]: [ePIC streaming workflow testbed planning document](https://docs.google.com/document/d/1mPqMsjHiymkeAB7uih_8TjFIluwM8MENIWZF3EDwNrU/edit?tab=t.0)
 

--- a/docs/diagram7_corunai_codocai.md
+++ b/docs/diagram7_corunai_codocai.md
@@ -22,7 +22,7 @@ flowchart TB
 
     CODOC["<b>codoc-ai</b> — immediate application<br/>documentation drafting · production analysis"]:::codoc
 
-    CORUN["<b>corun-ai</b> scheduler<br/>config = model × sysprompt × MCP set<br/>configure · dispatch · compare"]:::orch
+    corun-ai["<b>corun-ai</b> scheduler<br/>config = model × sysprompt × MCP set<br/>configure · dispatch · compare"]:::orch
 
     subgraph MODELS["Model ensemble — three providers, common scheduler"]
         direction LR
@@ -38,10 +38,10 @@ flowchart TB
     OUT["<b>codoc-ai outputs</b><br/>documentation drafts · production-examination reports ·<br/>cross-model comparison threads (user annotations)"]:::out
 
     U --> CODOC
-    CODOC --> CORUN
-    CORUN --> M1
-    CORUN --> M2
-    CORUN --> M3
+    CODOC --> corun-ai
+    corun-ai --> M1
+    corun-ai --> M2
+    corun-ai --> M3
     M3 -. hosted by .-> REMOTE
     M1 --> MCP
     M2 --> MCP


### PR DESCRIPTION
## v37 (2026-07-10)

This baseline completes the first end-to-end pass of ePIC automated production. A production request enters through deterministic intake — the new request composer (part of this release) or automated import from the existing questionnaire — rather than a hand-tended spreadsheet; PCS composes it into configured tasks; a continuum of campaign catalogs map to ePIC's monthly cadence; the production operations agent submits to PanDA and records each physical attempt; produced data is reconciled from Rucio back onto the campaign catalog; and campaign succession runs as a reviewed AI proposal set — an LLM digests the production meeting record and drafts the disposition set that seeds the next campaign, with an operator approving every disposition. The connective tissue — structured action logging, live policy, alarms, narratives — is also here.

### The Campaign Continuum (swf-monitor)

One curated catalog now spans every campaign, with lifecycle as an attribute rather than separate views:

- **Physics configurations and editions**: the campaign-invariant identity behind dataset editions (physics tag + evgen identity + background + sample variant) is resolved by a dedicated module with a never-guess policy — where a bound tag and the observed path conflict, the path wins and the edition is flagged; unresolved configurations can never falsely merge.
- **Campaign instancing**: a plan/execute step mints the next campaign's editions from the current catalog, honoring per-configuration dispositions, with a review panel on the producing tab and truthful post-run reporting. Disposition resolution is configuration-wide, not per-row.
- **Propagation dispositions**: continue / hold / final per physics configuration, recommendations by AI based on plan analysis but flipped only by humans, each flip carrying a required comment into an append-only history; bulk catalog action with badges on non-continue rows.
- **Requests over physics configurations**: production requests bind to the configuration identity and project onto campaign editions, imported and composed requests alike.
- **Lifecycle surfaces**: a symmetric tab strip over past / last / current / producing / future; producing is derived from live Rucio arrivals, never stored; one-click promote rotation; the future tab detects the coming campaign from pending disposition batches (as determined from e.g. the LLM analyzing presentations at Physics, S&C planning meetings, as in the case of the July 8 meeting) and applies the instancing treatment on detection.
- **Firsthand Rucio reconciliation**: a producing campaign's records track Rucio directly — known DIDs refresh counts and replica status, unknown DIDs resolve to physics configurations before any row is created; the arrivals sweep watches all campaigns with one shallow query per root, and the past-campaign ingest runs as a nightly chain step.
- **Edition data pages**: every physics configuration navigates to its per-campaign Rucio data — real DIDs, files, volume, per-RSE replica status — linked from the catalog, the compose view, and the physics-configuration view.

### AI Proposals (swf-monitor)

The AI proposal subsystem is v1-complete and campaign succession is its first production use: the LLM proposes, a human decides, execution is deterministic.

- `src/ai/` is a first-class Django app with a canonical proposal ledger, queue page, and stable references (`cp-N`) usable from the bot MCP surface.
- The catalog is a first-class decision site: proposal blocks on the compose detail, left-panel badges, decision quality recorded on approval, and an undo verb that returns a row to pending with an unwind-complete record.
- AI presence follows one visual convention — bordered lavender blocks, purple titles only on AI pages — and the AI marker follows the voice of the artifact, not its authorship.

### Campaign Narratives (swf-monitor)

Campaign narratives are the human record of each campaign's intent and outcome: a collapsible narratives page with detail pages, comments, expert editing in the house style, a publish control, and a version lifecycle replacing draft/locked. Conventions are documented in `EPICPROD_NARRATIVES.md`. These may be created by LLMs, as in July, when an LLM analyzed presentations at the July 8 PS&C meeting and produced general and 26.07 specific campaign narratives which will guide automated daily and weekly assessments of the campaign.

### The epicprod Action Stream (swf-monitor)

Every substantive epicprod action — agent handler, MCP tool, web-tier operation — now records one structured record with outcome, duration, requesting user, and failure reason, giving the system a single operational memory:

- **Sublevel and live axes**: each action declares its importance and live-stream recommendation; the effective live policy is a SysConfig override editable on the live-policy page; the Logs page carries the live stream view, importance thresholds, and user/instance/module filters.
- **SysConfig**: database-backed system configuration with a System-page editor; reads are read-or-seed, so every key is visible at its default — no hidden knobs.
- **Nightly catalog sync**: a cron-enqueued chain — CSV import, questionnaire import, association sweep with auto-intake of direct `group.EIC` submissions (adopted tasks, the standing born-vs-adopted migration metric), Rucio output snapshot, EVGEN assimilation, questionnaire automatch, match cache, progress refresh — each step logged with measured durations.
- **Questionnaire automatch**: standing LLM matching of requests to tasks with batched calls, an exact-beam rule enforced in code, and event-driven rescans.
- **Alarms on the stream**: catalog-sync freshness and payload-fetch-rate alarms; alarm email moved to the BNL SMTP relay.
- **epicprod-live Mattermost publisher** posting as a dedicated bot account, and the PanDA bot renamed to DISpatcher (the ePIC-chosen name) with an expanded MCP tool admission list.

### Production Request Composer (swf-monitor)

`/pcs/request/` is the native production-request intake on the path to replacing the Google Form. A requester describes the physics in plain terms and the page shows, live, the matching configurations the system already has — adopting one records the same configuration anchor the CSV import writes. PWG and DSC are distinct fields carrying the official collaboration lists (the five physics working groups; the fifteen detector subsystem collaborations, grouped by region) with an Other escape; contact fields prefill from real user data; submission is external-safe through the devcloud proxy and gated by login. The composer is also the first "my epicprod" surface: a signed-in user's previous requests are the starting point for the next one.

### PanDA Task Operations and Job Diagnosis (swf-monitor)

- Physical PanDA attempts are first-class: `PandaTasks` records every submission, `.tryN` names give each whole-task rerun its own PanDA task and Rucio namespace, and the compose page exposes the three native operations — add another retry, restart-and-retry failures, rerun entire task — gated by PanDA task state.
- Job pages gained a study action with cached diagnosis; ePIC production job diagnosis surfaces in the task job list; payload logs are fetched before study and `.tryN` propagates to payload outputs.
- Task and job parameter rendering was cleaned throughout: linked URL parameters, text-view transpath links, content-sized tables, zero counts without state color.

### AI Assessments (swf-monitor)

Append-only AI assessments extend to production campaigns as a subject type, are stored as corun-ai artifacts with the local mechanism retained for migration, and carry review comments and quality metadata with standard retrieval through MCP.

### Platform and Operations (swf-monitor)

- **SSE serves from the ASGI worker** — the durable fix for the pinned-worker 503 outages; long-held streams no longer occupy mod_wsgi workers.
- **Nightly swfdb backup** with built-in integrity verification.
- **Catalog page-load containment**: the current-campaign table, campaign progress, and questionnaire matches are cached with nightly rebuild and activity-triggered refresh; page-load work is instrumented and bounded.
- **Deployment**: the lightweight deploy covers the ai app; the full deploy restarts the prod-ops agent; a pre-commit checks script encodes the compile/system-check/template-lint gate.

### UI Standards (swf-monitor)

- One button-role convention everywhere: solid variants act, outlines are reserved for stateful toggles.
- Operator actions are visible but inactive for non-operator viewers — every viewer sees what operators can do.
- Timestamps display in Eastern time throughout; editors fit the visible window; dropdown group headers render high-contrast in any browser theme.
- Generators display in their authors' spelling (BeAGLE, EpIC); Q² range labels parse in both the `1to10` and `1_10` spellings by value.

### Documentation and Diagrams (swf-monitor)

- New diagrams: the epicprod system overview, the operations automation loop, and the action stream.
- README, CLAUDE.md, and PCS.md point to the official ePIC WFMS documentation (<https://epic-wfms-docs.readthedocs.io>); the external-access contract now states the proxy catch-all reality; corun-ai naming is used throughout.

### swf-testbed

- Documentation points to the official WFMS documentation; the baseline branch reference is version-free; an E0–E1 workflow schematic was added.
- Folded in from main (merged during the cycle): integration-test refactor into a `workflow_call` with explicit per-repo checkout and CI on the baseline branch, `data_agent` rucio_comms cleanup, STF-file status polling in the prompt-processing workflow with configurable interval and timeout, processing STF files no longer reclaimed, and user-testbed start for prompt processing via MCP.

### swf-common-lib

- README points to the official WFMS documentation.

### Acknowledgments

Direct-to-main contributions folded into this baseline: **Dmitry Kalinkin** (integration-test `workflow_call` refactor, explicit checkout repos, `data_agent` cleanup, CI on the baseline branch) and **Zhaoyu Yang** (STF-status polling in prompt processing, processing-file reclaim fix, MCP user-testbed start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
