### PR TITLE
v38 baseline — the production domain gets its repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,4 @@ jobs:
       # Use the exact commit that triggered this run so PRs test their own code.
       swf_testbed_repo: ${{ github.repository }}
       swf_testbed_ref: ${{ github.sha }}
-      # Needed for https://github.com/BNLNPPS/swf-monitor/commit/00e14c514efd0a54f9b0b89e92886d277643f60f
-      # change to main when merged
-      swf_monitor_ref: infra/baseline-v37
+      swf_monitor_ref: main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ swf_list_logs(execution_id='...')         # Workflow logs
 
 ## Project-Specific Rules
 
-**Branch:** All 3 repos must be on the latest `infra/baseline-vNN` — the current baseline branch is always the working branch
+**Branch:** All 3 repos must be on the latest `infra/baseline-vNN` — the current baseline branch is always the working branch (`swf-epicprod` is outside the coordinated set and rides `main`)
 
 **First push:** `git push -u origin branch-name` sets up tracking.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # swf-testbed
 
-This is the umbrella repository for the ePIC streaming workflow testbed.
+This is the umbrella repository for the ePIC streaming workflow testbed: the streaming workflow
+application of the swf platform. Its production peer is
+[swf-epicprod](https://github.com/BNLNPPS/swf-epicprod); both ride the common platform in
+[swf-monitor](https://github.com/BNLNPPS/swf-monitor) and
+[swf-common-lib](https://github.com/BNLNPPS/swf-common-lib).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the umbrella repository for the ePIC streaming workflow testbed.
 - [**Workflow Orchestration**](docs/workflows.md) - Running and managing workflows
 - [**Monitor Integration**](docs/monitor.md) - Web interface and API usage
 - [**MCP Integration**](../swf-monitor/docs/MCP.md) - Model Context Protocol for LLM interaction
-- [**PCS (Physics Configuration System)**](../swf-monitor/docs/PCS.md) - Production metadata tags for MC campaigns
+- [**PCS (Physics Configuration System)**](../swf-epicprod/docs/PCS.md) - Production configuration and campaign records, in the [swf-epicprod](https://github.com/BNLNPPS/swf-epicprod) production domain
 - [**SSE Real-Time Streaming**](docs/sse-streaming.md) - Remote workflow event monitoring via HTTPS
 - [**Production Deployment**](../swf-monitor/docs/PRODUCTION_DEPLOYMENT.md) - Apache production deployment guide
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,54 @@
 # Release Notes
 
+## v38 (2026-07-10)
+
+This release factors (part of) the production domain into its own repository. the PCS application and the epicprod documentation now
+live in [swf-epicprod](https://github.com/BNLNPPS/swf-epicprod), a peer application of swf-testbed, and the core
+repositories consistently express the framing: swf is the brand, swf-testbed and swf-epicprod are its applications,
+and swf-monitor and swf-common-lib are the common platform they ride on. Nothing changes for users — all pages,
+URLs, APIs, and tools are unchanged.
+
+### swf-epicprod — the Production Domain Repository
+
+- `docs/ARCHITECTURE_MAP.md` is the plan of record for the code organization: each platform and production
+  component's home, destination, and consumption interface, with the placement test, the mechanism/policy split for
+  borderline components, and the migration order. Existing components migrate case by case, when the alternative is
+  substantial new work landing in swf-monitor.
+- The PCS application moved in with its identity preserved — import path, app label, and database tables are
+  unchanged — so settings, URLs, cross-app imports, and migration history required no changes. PCS ships as an
+  installable Django application consumed by the swf-monitor runtime, editable in the shared development venv and
+  frozen non-editable into the deployed venv at deploy time.
+- The epicprod documentation set (the PCS docs, the EPICPROD set, JEDI integration, campaign continuum,
+  commissioning relaxations) moved in with its figures. Every moved document leaves a permanent stub at its old
+  path, so existing bookmarks and references resolve. The repository is solo-maintained on `main`, outside the
+  coordinated baseline branch set.
+
+### Platform (swf-monitor, swf-common-lib, swf-testbed)
+
+- swf-monitor's README, guidelines, and doc index state its platform role — the common monitor, web, and database
+  services, serving the testbed and epicprod, hosting production applications installed from swf-epicprod — and its
+  documentation now covers the platform services alone. The action stream documentation is renamed
+  `ACTION_STREAM.md`: the stream machinery is platform, with epicprod its principal user.
+- swf-common-lib's README describes the library of the swf platform, serving both applications.
+- swf-testbed's installer and installation guide carry the four-repository layout; a fresh environment now installs
+  swf-epicprod alongside the core three. The testbed README places the testbed in the swf application family.
+- The swf-monitor deploy freezes swf-epicprod into the deployed venv (invoking pip as `python -m pip`, since a
+  copied venv's pip script operates on its source venv), and the lightweight deploy syncs PCS from the swf-epicprod
+  tree onto the deployed venv's installed copy.
+
+### Campaign Assessments Design (swf-epicprod docs)
+
+`EPICPROD_ASSESSMENTS.md` is the design for scheduled nightly and weekly LLM assessments of producing campaigns:
+corun-ai executes under its own credentials and configuration; a campaign analytics library carries the
+deterministic computation and serves the dashboard, the assessor, and a campaign-status MCP tool; assessments
+follow a versioned artifact schema with a structured block, bounded prose, and a standalone narration for thin
+delivery channels; the harness enforces the schema and resolves every scheduled slot to a visible outcome. This is
+the charter for the next cycle's work.
+
+### Acknowledgments
+
+Folded in from main: **Dmitry Kalinkin** — a GitHub Action verifying agent operability against swf-monitor (#36).
+
 ## v37 (2026-07-10)
 
 This baseline completes the first end-to-end pass of ePIC automated production. A production request enters through deterministic intake — the new request composer (part of this release) or automated import from the existing questionnaire — rather than a hand-tended spreadsheet; PCS composes it into configured tasks; a continuum of campaign catalogs map to ePIC's monthly cadence; the production operations agent submits to PanDA and records each physical attempt; produced data is reconciled from Rucio back onto the campaign catalog; and campaign succession runs as a reviewed AI proposal set — an LLM digests the production meeting record and drafts the disposition set that seeds the next campaign, with an operator approving every disposition. The connective tissue — structured action logging, live policy, alarms, narratives — is also here.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,9 @@ The repositories mapping to testbed components are:
 
 ### [swf-monitor](https://github.com/BNLNPPS/swf-monitor)
 
-A web service providing system monitoring and comprehensive information about the testbed's state, both via browser-based dashboards and a json based REST API.
+The common monitor, web, and database services of the swf platform, serving the testbed and the epicprod production system: browser-based dashboards, a JSON REST API, and the database-backed state beneath them.
 
-This module manages the databases used by the testbed, and offers a REST API for other agents in the system to report status and retrieve information. It acts as a listener for the ActiveMQ message broker, receiving messages from other agents, storing relevant data in the database and presenting message histories in the monitor. It hosts a Model Context Protocol (MCP) server for the agents to share information with LLM clients to create an intelligent assistant for the testbed.
+This module manages the databases used by the testbed, and offers a REST API for other agents in the system to report status and retrieve information. It acts as a listener for the ActiveMQ message broker, receiving messages from other agents, storing relevant data in the database and presenting message histories in the monitor. It hosts a Model Context Protocol (MCP) server for the agents to share information with LLM clients to create an intelligent assistant for the testbed. Production applications ship from [swf-epicprod](https://github.com/BNLNPPS/swf-epicprod) and run installed within the monitor's runtime.
 
 ### [swf-daqsim-agent](https://github.com/BNLNPPS/swf-daqsim-agent)
 

--- a/docs/architecture_and_design_choices.md
+++ b/docs/architecture_and_design_choices.md
@@ -82,7 +82,7 @@ contributors and for future architectural reviews.
 
 - **API and consumers:** the API is documented in the `swf-common-lib` README;
   the first consumer is the epicprod ops agent
-  (`swf-monitor/docs/EPICPROD_OPS_AGENT.md`).
+  (`swf-epicprod/docs/EPICPROD_OPS_AGENT.md`).
 
 ### Messaging Semantics: Topic vs Queue vs Durable Subscription
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ coordination to maintain system stability and integration.
 The testbed is composed of three core repositories that must be kept as siblings:
 
 - **swf-testbed**: Core testbed infrastructure, CLI, and orchestration
-- **swf-monitor**: Django web application for monitoring and data management
+- **swf-monitor**: the platform's common monitor, web, and database services (Django)
 - **swf-common-lib**: Shared utilities and common code
 
 Additional repositories will be added as the testbed expands with new agents,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,12 +23,14 @@ mkdir swf-project && cd swf-project
 git clone https://github.com/BNLNPPS/swf-testbed.git
 git clone https://github.com/BNLNPPS/swf-monitor.git
 git clone https://github.com/BNLNPPS/swf-common-lib.git
+git clone https://github.com/BNLNPPS/swf-epicprod.git
 
 # Your directory structure should now look like:
 # swf-project/
 # ├── swf-testbed/
 # ├── swf-monitor/
-# └── swf-common-lib/
+# ├── swf-common-lib/
+# └── swf-epicprod/
 ```
 
 ## Step 2: Environment Configuration
@@ -178,6 +180,9 @@ source .venv/bin/activate
    # Install swf-monitor (Django web application)
    pip install -e ../swf-monitor
 
+   # Install swf-epicprod (production applications, installed into the monitor runtime)
+   pip install -e ../swf-epicprod
+
    # Install swf-testbed CLI
    pip install -e .
    ```
@@ -194,7 +199,7 @@ if it is applied to this venv:
 2. **dev-update** — re-run the editable install so the venv, and the editable
    package metadata that `pip check` reads, reflect the change:
    ```bash
-   pip install -e ../swf-common-lib ../swf-monitor .
+   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod .
    ```
    Removing a dependency? `pip install` never uninstalls — `pip uninstall` the
    orphan explicitly.
@@ -346,7 +351,7 @@ The Django application will automatically read these values during startup.
 5. **Import errors:**
    ```bash
    # Reinstall packages in correct order
-   pip install -e ../swf-common-lib ../swf-monitor .
+   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod .
    ```
 
 ## Next Steps

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ SWF_PARENT_DIR=$(dirname "$(pwd)")
 export SWF_PARENT_DIR
 SWF_COMMON_LIB="$SWF_PARENT_DIR/swf-common-lib"
 SWF_MONITOR="$SWF_PARENT_DIR/swf-monitor"
+SWF_EPICPROD="$SWF_PARENT_DIR/swf-epicprod"
 
 echo "📁 Checking for required repositories..."
 if [[ ! -d "$SWF_COMMON_LIB" ]]; then
@@ -31,6 +32,13 @@ if [[ ! -d "$SWF_MONITOR" ]]; then
     echo "❌ Error: swf-monitor not found at $SWF_MONITOR"
     echo "   swf-monitor is REQUIRED (contains core Django infrastructure and database models)"
     echo "   Please clone: git clone https://github.com/BNLNPPS/swf-monitor.git"
+    exit 1
+fi
+
+if [[ ! -d "$SWF_EPICPROD" ]]; then
+    echo "❌ Error: swf-epicprod not found at $SWF_EPICPROD"
+    echo "   swf-epicprod is REQUIRED (production applications installed into the monitor runtime)"
+    echo "   Please clone: git clone https://github.com/BNLNPPS/swf-epicprod.git"
     exit 1
 fi
 
@@ -56,20 +64,23 @@ python -m pip install --upgrade pip
 # Install dependencies in correct order
 echo "📦 Installing Python packages in dependency order..."
 
-echo "  1/4 Installing swf-common-lib (shared utilities)..."
+echo "  1/5 Installing swf-common-lib (shared utilities)..."
 pip install -e "$SWF_COMMON_LIB"
 
-echo "  2/4 Installing swf-monitor dependencies..."
+echo "  2/5 Installing swf-monitor dependencies..."
 if [[ -f "$SWF_MONITOR/requirements.txt" ]]; then
     pip install -r "$SWF_MONITOR/requirements.txt"
 else
     echo "    No requirements.txt found in swf-monitor"
 fi
 
-echo "  3/4 Installing swf-monitor (core Django infrastructure)..."
+echo "  3/5 Installing swf-monitor (core Django infrastructure)..."
 pip install -e "$SWF_MONITOR"
 
-echo "  4/4 Installing swf-testbed CLI and core dependencies..."
+echo "  4/5 Installing swf-epicprod (production applications)..."
+pip install -e "$SWF_EPICPROD"
+
+echo "  5/5 Installing swf-testbed CLI and core dependencies..."
 # Install core dependencies first
 pip install typer[all] supervisor psutil
 # Install testbed without trying to resolve the swf-* dependencies from PyPI


### PR DESCRIPTION
## v38 (2026-07-10)

This release factors (part of) the production domain into its own repository. the PCS application and the epicprod documentation now
live in [swf-epicprod](https://github.com/BNLNPPS/swf-epicprod), a peer application of swf-testbed, and the core
repositories consistently express the framing: swf is the brand, swf-testbed and swf-epicprod are its applications,
and swf-monitor and swf-common-lib are the common platform they ride on. Nothing changes for users — all pages,
URLs, APIs, and tools are unchanged.

### swf-epicprod — the Production Domain Repository

- `docs/ARCHITECTURE_MAP.md` is the plan of record for the code organization: each platform and production
  component's home, destination, and consumption interface, with the placement test, the mechanism/policy split for
  borderline components, and the migration order. Existing components migrate case by case, when the alternative is
  substantial new work landing in swf-monitor.
- The PCS application moved in with its identity preserved — import path, app label, and database tables are
  unchanged — so settings, URLs, cross-app imports, and migration history required no changes. PCS ships as an
  installable Django application consumed by the swf-monitor runtime, editable in the shared development venv and
  frozen non-editable into the deployed venv at deploy time.
- The epicprod documentation set (the PCS docs, the EPICPROD set, JEDI integration, campaign continuum,
  commissioning relaxations) moved in with its figures. Every moved document leaves a permanent stub at its old
  path, so existing bookmarks and references resolve. The repository is solo-maintained on `main`, outside the
  coordinated baseline branch set.

### Platform (swf-monitor, swf-common-lib, swf-testbed)

- swf-monitor's README, guidelines, and doc index state its platform role — the common monitor, web, and database
  services, serving the testbed and epicprod, hosting production applications installed from swf-epicprod — and its
  documentation now covers the platform services alone. The action stream documentation is renamed
  `ACTION_STREAM.md`: the stream machinery is platform, with epicprod its principal user.
- swf-common-lib's README describes the library of the swf platform, serving both applications.
- swf-testbed's installer and installation guide carry the four-repository layout; a fresh environment now installs
  swf-epicprod alongside the core three. The testbed README places the testbed in the swf application family.
- The swf-monitor deploy freezes swf-epicprod into the deployed venv (invoking pip as `python -m pip`, since a
  copied venv's pip script operates on its source venv), and the lightweight deploy syncs PCS from the swf-epicprod
  tree onto the deployed venv's installed copy.

### Campaign Assessments Design (swf-epicprod docs)

`EPICPROD_ASSESSMENTS.md` is the design for scheduled nightly and weekly LLM assessments of producing campaigns:
corun-ai executes under its own credentials and configuration; a campaign analytics library carries the
deterministic computation and serves the dashboard, the assessor, and a campaign-status MCP tool; assessments
follow a versioned artifact schema with a structured block, bounded prose, and a standalone narration for thin
delivery channels; the harness enforces the schema and resolves every scheduled slot to a visible outcome. This is
the charter for the next cycle's work.

### Acknowledgments

Folded in from main: **Dmitry Kalinkin** — a GitHub Action verifying agent operability against swf-monitor (#36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
