### PR TITLE
Integration image installs swf-epicprod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,16 @@ RUN pip install --no-cache-dir -r /build/swf-monitor/requirements.txt \
     && pip install --no-cache-dir django-mcp-server django-oauth-toolkit uvicorn \
     && pip install --no-cache-dir /build/swf-monitor
 
-# 3. swf-testbed itself (typer CLI, supervisor, psutil, simpy, etc.)
+# 3. swf-epicprod (production applications installed into the monitor runtime;
+#    provides the pcs package in swf-monitor's INSTALLED_APPS). Cloned from
+#    GitHub so the build context stays the three-repo checkout; override with
+#    --build-arg SWF_EPICPROD_REF=<branch|tag> if needed.
+ARG SWF_EPICPROD_REF=main
+RUN git clone --depth 1 --branch "${SWF_EPICPROD_REF}" \
+        https://github.com/BNLNPPS/swf-epicprod.git /build/swf-epicprod \
+    && pip install --no-cache-dir /build/swf-epicprod
+
+# 4. swf-testbed itself (typer CLI, supervisor, psutil, simpy, etc.)
 RUN pip install --no-cache-dir /build/swf-testbed
 
 # --------------- runtime stage: slim image -----------------------------------


### PR DESCRIPTION
Companion to BNLNPPS/swf-monitor#39: the testbed image installs swf-monitor, whose settings list the pcs application shipping from swf-epicprod since the v38 baseline. The build stage clones and installs swf-epicprod with a `SWF_EPICPROD_REF` build-arg, matching the swf-monitor image pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)