### PR TITLE
Baseline v40: release notes, runner state finalization, site-canary

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,91 @@
 # Release Notes
 
+## v40 (2026-07-25)
+
+This release adds Snapper, which records subsystem-published operational state as a queryable history, with a
+report page for browsing that history over time. At the end of the cycle the Snapper UI moved from swf-monitor
+into the snapper-ai package, with the experiment-specific parts supplied by the host through a registration
+interface. The cycle also installs the site-canary health checks, corrects the PanDA final-failure metric,
+speeds up the PanDA tasks list, and fixes several failure modes in broker-dependent operations. These notes
+cover the coordinated baseline repositories and the relevant `main` work in their peer repositories.
+
+### Snapper (snapper-ai, swf-monitor, swf-testbed)
+
+- The [snapper-ai](https://github.com/BNLNPPS/snapper-ai) repository holds the package: registered bounded
+  components published by their owning subsystems, change-driven capture at aligned boundaries with periodic
+  baselines, immutable full snaps, and temporal queries (latest, state-at, component history, changes-between,
+  context-around). Query results carry actual snap times, provenance, and observer-coverage status, including
+  recovery gaps recorded as immutable intervals.
+- Three components are in production: System health in both scopes, testbed datataking state with per-namespace
+  lanes discovered from the run records, and the epicprod PanDA activity projection with current in-flight job
+  and task states by target site. A five-day commissioning read closed the initial measurement phase; capture
+  now runs once per aligned boundary and logs only material events.
+- The queries are exposed through read-open REST endpoints and five MCP tools, and the three registered event
+  resolvers map to their authoritative services.
+- The report page shows the recorded history: namespace lanes drawn as idle tracks with tiles for run activity,
+  per-family curve panels sharing one time axis and crosshair, and a click-placed cut that renders the state at
+  that instant as component cards. The cards and the lanes derive from the same run-record query so they cannot
+  disagree. Zoom and cut state are carried in the URL. Window arrows step through the recorded history; an
+  arrow is omitted only at the newest data or the earliest snap. All times are Eastern.
+- On the testbed side, run lifecycle messages now update RunState and republish the datataking component, and
+  the workflow runner clears execution and announced-run state on every exit path. Stale historical run and
+  execution records were repaired, and a System check now reports any state record that claims activity without
+  supporting evidence.
+- The UI moved into the snapper-ai package. A host registers per-scope providers (curve extraction, labels and
+  groupings, component cards rendered through a host template, activity lanes, reference resolution) and
+  service hooks (preferences, configuration, scheduler status); unregistered pieces fall back to generic
+  rendering. `docs/INTEGRATION.md` describes the integration steps with the swf-monitor integration as the
+  example, and the repository includes report-page screenshots for both scopes.
+
+### PanDA metrics and tasks list (swf-monitor)
+
+- The final-failure metric was wrong: it counted failed job records with `attemptnr >= maxattempt`, but JEDI
+  sets each job record's maxattempt equal to its own attempt number, so every failed record matched and the
+  "final" rate equalled the all-failures rate. Jobs that failed and then succeeded on retry were counted as
+  final failures. The metric now counts retry-exhausted input files from `jedi_datasets`, which matches what
+  the PanDA monitor reports. The task pages, the failure-rate alarms, and the campaign analytics all use the
+  corrected definition.
+- Task pages and the tasks list now also show average retries per successful job (0 means every job passed on
+  its first attempt), as a measure of how much retry churn sits behind the successes.
+- The tasks list previously re-aggregated job counts from the PanDA database on every sort and page change,
+  which took about two seconds for sorts on computed columns. The list is now served from a cached full-window
+  aggregation rebuilt at most every two minutes; sorts and paging run against the cache and return in tens of
+  milliseconds. The same caching mechanism (`docs/CACHED_PRODUCTS.md`) serves the error summary, which now
+  reports average time-to-error per pattern and runs a single scan of the jobs tables.
+- Tasks that PCS discovered and linked through the nightly sync or the association sweep were displaying the
+  sweep's name as the task owner. The owner display and filter now fall back to the PanDA username for those
+  tasks; `created_by` on the PCS records is unchanged.
+
+### site-canary and operations (site-canary, swf-monitor, swf-testbed)
+
+- The site-canary store, page, and site-health agent are installed in the shared environment and frozen into
+  the release venv at deploy.
+- Following an investigation of dropped messages, the System page gains an activemq-broker check (handshake
+  latency, recent drops, heap, connections, dead-letter queue depth) with per-check Retry buttons that re-probe
+  a single check through the operations agent. Production enqueues now retry across transient broker handshake
+  failures, and the lightweight deployment warms the recycled application so the first external request after a
+  deploy no longer times out.
+
+### Platform, deployment, and peer mainline work
+
+- The lightweight deployment syncs the snapper-ai package alongside pcs; the full deploy freezes it into the
+  release venv. Campaign narratives list in reverse campaign order; the assessments list shows the narration,
+  with verdict badges on the detail page; User Analysis navigation and cursor handling were fixed.
+- swf-common-lib `main` (external contributions) added the `rucio_utils` package and removed the `mq_comms` and
+  `rucio_comms` modules; the testbed agents switched to the package imports (#62). This work is folded into the
+  baseline at the release boundary.
+- swf-epicprod `main` added assessment crash handling: a run that dies before submitting its result is
+  resubmitted once, and a labeled salvage report carrying the mechanical verdict floor is registered so the
+  scheduled slot is never silently empty. The campaign analytics and progress summaries carry the corrected
+  final-failure definition.
+
+### Acknowledgments
+
+- Dmitry Kalinkin contributed the swf-common-lib `rucio_utils` package, the retirement of the superseded
+  `mq_comms` and `rucio_comms` modules, the common-lib CI workflow, and the testbed agents' switch to the
+  package imports.
+- Sakib Rahman reported the final-failure metric discrepancy and proposed the average-retries metric.
+
 ## v39 (2026-07-17)
 
 This release defines the ePIC E0-E1 interface as understood in mid 2026 and turns the campaign-assessment design

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,8 +13,8 @@ Before starting, ensure you have:
 
 ## Step 1: Clone the Repositories
 
-Clone the SWF repositories and snapper-ai as siblings in the same parent
-directory:
+Clone the SWF repositories, snapper-ai, and site-canary as siblings in the
+same parent directory:
 
 ```bash
 # Create a directory for the SWF project
@@ -26,6 +26,7 @@ git clone https://github.com/BNLNPPS/swf-monitor.git
 git clone https://github.com/BNLNPPS/swf-common-lib.git
 git clone https://github.com/BNLNPPS/swf-epicprod.git
 git clone https://github.com/BNLNPPS/snapper-ai.git
+git clone https://github.com/BNLNPPS/site-canary.git
 
 # Your directory structure should now look like:
 # swf-project/
@@ -33,7 +34,8 @@ git clone https://github.com/BNLNPPS/snapper-ai.git
 # ├── swf-monitor/
 # ├── swf-common-lib/
 # ├── swf-epicprod/
-# └── snapper-ai/
+# ├── snapper-ai/
+# └── site-canary/
 ```
 
 ## Step 2: Environment Configuration
@@ -189,6 +191,9 @@ source .venv/bin/activate
    # Install snapper-ai (operational history, installed into the monitor runtime)
    pip install -e ../snapper-ai
 
+   # Install site-canary (site health, installed into the monitor runtime)
+   pip install -e '../site-canary[store]'
+
    # Install swf-testbed CLI
    pip install -e .
    ```
@@ -205,7 +210,7 @@ if it is applied to this venv:
 2. **dev-update** — re-run the editable install so the venv, and the editable
    package metadata that `pip check` reads, reflect the change:
    ```bash
-   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod ../snapper-ai .
+   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod ../snapper-ai '../site-canary[store]' .
    ```
    Removing a dependency? `pip install` never uninstalls — `pip uninstall` the
    orphan explicitly.
@@ -357,7 +362,7 @@ The Django application will automatically read these values during startup.
 5. **Import errors:**
    ```bash
    # Reinstall packages in correct order
-   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod ../snapper-ai .
+   pip install -e ../swf-common-lib ../swf-monitor ../swf-epicprod ../snapper-ai '../site-canary[store]' .
    ```
 
 ## Next Steps

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ SWF_COMMON_LIB="$SWF_PARENT_DIR/swf-common-lib"
 SWF_MONITOR="$SWF_PARENT_DIR/swf-monitor"
 SWF_EPICPROD="$SWF_PARENT_DIR/swf-epicprod"
 SNAPPER_AI="$SWF_PARENT_DIR/snapper-ai"
+SITE_CANARY="$SWF_PARENT_DIR/site-canary"
 
 echo "📁 Checking for required repositories..."
 if [[ ! -d "$SWF_COMMON_LIB" ]]; then
@@ -50,6 +51,13 @@ if [[ ! -d "$SNAPPER_AI" ]]; then
     exit 1
 fi
 
+if [[ ! -d "$SITE_CANARY" ]]; then
+    echo "❌ Error: site-canary not found at $SITE_CANARY"
+    echo "   site-canary is REQUIRED (site health application installed into the monitor runtime)"
+    echo "   Please clone: git clone https://github.com/BNLNPPS/site-canary.git"
+    exit 1
+fi
+
 echo "✅ All required repositories found"
 
 # Create virtual environment if it doesn't exist
@@ -72,26 +80,29 @@ python -m pip install --upgrade pip
 # Install dependencies in correct order
 echo "📦 Installing Python packages in dependency order..."
 
-echo "  1/6 Installing swf-common-lib (shared utilities)..."
+echo "  1/7 Installing swf-common-lib (shared utilities)..."
 pip install -e "$SWF_COMMON_LIB"
 
-echo "  2/6 Installing swf-monitor dependencies..."
+echo "  2/7 Installing swf-monitor dependencies..."
 if [[ -f "$SWF_MONITOR/requirements.txt" ]]; then
     pip install -r "$SWF_MONITOR/requirements.txt"
 else
     echo "    No requirements.txt found in swf-monitor"
 fi
 
-echo "  3/6 Installing swf-monitor (core Django infrastructure)..."
+echo "  3/7 Installing swf-monitor (core Django infrastructure)..."
 pip install -e "$SWF_MONITOR"
 
-echo "  4/6 Installing swf-epicprod (production applications)..."
+echo "  4/7 Installing swf-epicprod (production applications)..."
 pip install -e "$SWF_EPICPROD"
 
-echo "  5/6 Installing snapper-ai (operational history application)..."
+echo "  5/7 Installing snapper-ai (operational history application)..."
 pip install -e "$SNAPPER_AI"
 
-echo "  6/6 Installing swf-testbed CLI and core dependencies..."
+echo "  6/7 Installing site-canary (site health application)..."
+pip install -e "$SITE_CANARY[store]"
+
+echo "  7/7 Installing swf-testbed CLI and core dependencies..."
 # Install core dependencies first
 pip install typer[all] supervisor psutil
 # Install testbed without trying to resolve the swf-* dependencies from PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "swf-common-lib",
     "swf-monitor",
     "snapper-ai",
+    "site-canary[store]",
     # "swf-daqsim-agent",
     # "swf-data-agent",
     # "swf-processing-agent",
@@ -42,3 +43,4 @@ where = ["src"]
 swf-common-lib = { path = "../swf-common-lib", editable = true }
 swf-monitor    = { path = "../swf-monitor",    editable = true }
 snapper-ai     = { path = "../snapper-ai",     editable = true }
+site-canary    = { path = "../site-canary",    editable = true }

--- a/workflows/workflow_runner.py
+++ b/workflows/workflow_runner.py
@@ -303,16 +303,24 @@ class WorkflowRunner(BaseAgent):
             config=config
         )
 
-        # Execute the workflow
-        self._execute_workflow(
-            execution_id=execution_id,
-            workflow_code=workflow_code,
-            config=config,
-            duration=duration,
-            realtime=realtime
-        )
-
-        # Update execution status to completed
+        # Execute the workflow. The execution record was created as
+        # 'running' and MUST reach a terminal status on every exit path —
+        # an abandoned 'running' row is a standing lie every monitoring
+        # surface then repeats. The same holds one level down: a failed
+        # workflow must not leave its announced runs claiming activity.
+        self._announced_runs = set()
+        try:
+            self._execute_workflow(
+                execution_id=execution_id,
+                workflow_code=workflow_code,
+                config=config,
+                duration=duration,
+                realtime=realtime
+            )
+        except BaseException:
+            self._update_execution_status(execution_id, 'failed')
+            self._abandon_announced_runs()
+            raise
         self._update_execution_status(execution_id, 'completed')
 
         return execution_id
@@ -645,11 +653,35 @@ class WorkflowRunner(BaseAgent):
         else:
             raise ValueError("WorkflowExecutor class not found in workflow code")
 
+    def _abandon_announced_runs(self):
+        """Terminalize the runs this execution announced but did not
+        end: a failed workflow leaves no run state claiming activity.
+        Failures to write are logged loudly — the stale-state detector
+        on the System page names any survivor."""
+        for run_number in sorted(getattr(self, '_announced_runs', ())):
+            try:
+                response = self.api_session.patch(
+                    f"{self.monitor_url}/api/run-states/{run_number}/",
+                    json={'phase': 'failed', 'state': 'abandoned',
+                          'substate': None,
+                          'state_changed_at': datetime.now().isoformat()}
+                )
+                if response.status_code != 200:
+                    self.logger.error(
+                        f"Failed to abandon run state {run_number}: "
+                        f"HTTP {response.status_code}")
+            except Exception as exc:
+                self.logger.error(
+                    f"Failed to abandon run state {run_number}: {exc}")
+
     def _update_execution_status(self, execution_id: str, status: str):
-        """Update workflow execution status"""
+        """Update workflow execution status; every terminal status
+        carries its end time."""
         payload = {
             'status': status,
-            'end_time': datetime.now().isoformat() if status == 'completed' else None
+            'end_time': (datetime.now().isoformat()
+                         if status in ('completed', 'failed', 'terminated')
+                         else None)
         }
 
         response = self.api_session.patch(
@@ -705,6 +737,9 @@ class WorkflowRunner(BaseAgent):
 
         if response.status_code in [200, 201]:
             self.logger.info(f"State initialized: {state_id}")
+            if not hasattr(self, '_announced_runs'):
+                self._announced_runs = set()
+            self._announced_runs.add(state_id)
             return True
 
         self.logger.error(f"Failed to initialize state: {response.status_code}")


### PR DESCRIPTION
The v40 coordinated baseline. The canonical release record is the v40 entry in `RELEASE_NOTES.md`, added here.

Summary for this repository:

- v40 release notes (Snapper, PanDA metrics corrections, tasks-list caching, site-canary, operations resilience, peer mainline work, acknowledgments).
- The workflow runner finalizes execution and announced-run state on every exit path, so crashes no longer leave false running state.
- site-canary installed in the shared SWF environment.
- `main` folded in at the release boundary: agents on the `swf_common_lib.rucio_utils` package imports (#62) and the example-agent logging fix.

Companion PR: BNLNPPS/swf-monitor#43. No swf-common-lib baseline PR: its cycle work landed on `main` directly and is credited in the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)