### PR TITLE
Testbed image installs site-canary before the meta-package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,13 @@ RUN git clone --depth 1 --branch "${SNAPPER_AI_REF}" \
         https://github.com/BNLNPPS/snapper-ai.git /build/snapper-ai \
     && pip install --no-cache-dir /build/snapper-ai
 
-# 5. swf-testbed itself (typer CLI, supervisor, psutil, simpy, etc.)
+# 5. site-canary (the swf-testbed meta-package requires site-canary[store]).
+ARG SITE_CANARY_REF=main
+RUN git clone --depth 1 --branch "${SITE_CANARY_REF}" \
+        https://github.com/BNLNPPS/site-canary.git /build/site-canary \
+    && pip install --no-cache-dir "/build/site-canary[store]"
+
+# 6. swf-testbed itself (typer CLI, supervisor, psutil, simpy, etc.)
 RUN pip install --no-cache-dir /build/swf-testbed
 
 # --------------- runtime stage: slim image -----------------------------------


### PR DESCRIPTION
Heals the CI failure on main after the v40 merge (run 30172791982): swf-testbed requires site-canary[store] since v40, but site-canary is not on PyPI, so pip could not resolve the meta-package during the integration image build. The image now clones and installs site-canary first, the same pattern as snapper-ai and swf-epicprod.

Companion: the swf-monitor image fix for the canary import in the monitor container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)